### PR TITLE
Visibility of optional fields

### DIFF
--- a/oq-ui-api/bin/oq-platform-install.sh
+++ b/oq-ui-api/bin/oq-platform-install.sh
@@ -18,7 +18,7 @@
 # version managements - use "master" or tagname to move to other versions
 
 export GEM_OQ_PLATF_GIT_REPO=git://github.com/gem/oq-platform.git
-export GEM_OQ_PLATF_GIT_VERS=v1.12.8
+export GEM_OQ_PLATF_GIT_VERS=toggle-optional-fields
 
 export GEM_OQ_PLATF_SUBMODS="oq-ui-client/app/static/externals/geoext
 oq-ui-client/app/static/externals/gxp

--- a/oq-ui-client2/src/app/faulted_earth/ObservationFeatureEditor.js
+++ b/oq-ui-client2/src/app/faulted_earth/ObservationFeatureEditor.js
@@ -63,6 +63,9 @@ faulted_earth.ObservationFeatureEditor = Ext.extend(gxp.plugins.FeatureEditor,
 	      return output;
 	  }
 
+	  // hide the optional fields by default
+	  output.toggleOptionalFields();
+
 	  // we are adding a popup with an editor, so let's bind the
 	  // rowclick event to show our context sensitive help
 	  var popup = output;


### PR DESCRIPTION
Allow the user to toggle the visibility of optional (or computed) fields in feature grid editors.

Default is to hide such fields.
