### PR TITLE
Disable open proxy setup by geonode

### DIFF
--- a/openquakeplatform/openquakeplatform/faulted_earth/static/faulted_earth/faulted_earth.js
+++ b/openquakeplatform/openquakeplatform/faulted_earth/static/faulted_earth/faulted_earth.js
@@ -30,8 +30,7 @@ Ext.Ajax.on('beforerequest', function (conn, options) {
 
     app = new gxp.Viewer(
       {
-        proxy: "/proxy/?url=",
-        localGeoServerBaseUrl: "http://localhost:8080/geoserver/",
+        localGeoServerBaseUrl: "/geoserver/",
         authorizedRoles: "ROLE_ADMINISTRATOR",
 
 	/* add a listener for computed fields */
@@ -337,7 +336,7 @@ Ext.Ajax.on('beforerequest', function (conn, options) {
             local: {
                 ptype: "gxp_wmscsource",
                 version: "1.1.1",
-              url: "http://localhost:8080/geoserver/wms"
+              url: "/geoserver/wms"
             },
             osm: {
                 ptype: "gxp_osmsource"

--- a/openquakeplatform/openquakeplatform/gaf_viewer/static/gaf_viewer/gaf_viewer.js
+++ b/openquakeplatform/openquakeplatform/gaf_viewer/static/gaf_viewer/gaf_viewer.js
@@ -38,8 +38,7 @@ Ext.onReady(function() {
 
 
     app = new gxp.Viewer({
-        proxy: "/proxy/?url=",
-        localGeoServerBaseUrl: "http://localhost:8080/geoserver/",
+        localGeoServerBaseUrl: "/geoserver/",
         authorizedRoles: "ROLE_ANONYMOUS",
 
         portalConfig: {
@@ -108,7 +107,7 @@ Ext.onReady(function() {
         sources: {
             local: {
                 ptype: "gxp_wmscsource",
-                url: "http://localhost:8080/geoserver/wms",
+                url: "/geoserver/wms",
                 version: "1.1.1"
             },
             osm: {

--- a/openquakeplatform/openquakeplatform/ghec_viewer/static/ghec_viewer/ghec_viewer.js
+++ b/openquakeplatform/openquakeplatform/ghec_viewer/static/ghec_viewer/ghec_viewer.js
@@ -16,8 +16,7 @@ Ext.onReady(function() {
 
 
     app = new gxp.Viewer({
-        proxy: "/proxy/?url=",
-        localGeoServerBaseUrl: "http://localhost:8080/geoserver/",
+        localGeoServerBaseUrl: "/geoserver/",
         authorizedRoles: "ROLE_ANONYMOUS",
 
         portalConfig: {
@@ -86,7 +85,7 @@ Ext.onReady(function() {
         sources: {
             local: {
                 ptype: "gxp_wmscsource",
-                url: "http://localhost:8080/geoserver/wms",
+                url: "/geoserver/wms",
                 version: "1.1.1"
             },
             osm: {

--- a/openquakeplatform/openquakeplatform/isc_viewer/static/isc_viewer/isc_viewer.js
+++ b/openquakeplatform/openquakeplatform/isc_viewer/static/isc_viewer/isc_viewer.js
@@ -16,8 +16,7 @@ Ext.onReady(function() {
 
     app = new gxp.Viewer(
       {
-        proxy: "/proxy/?url=",
-        localGeoServerBaseUrl: "http://localhost:8080/geoserver/",
+        localGeoServerBaseUrl: "/geoserver/",
         authorizedRoles: "ROLE_ANONYMOUS",
 
         portalConfig: {
@@ -86,7 +85,7 @@ Ext.onReady(function() {
         sources: {
             local: {
                 ptype: "gxp_wmscsource",
-                url: "http://localhost:8080/geoserver/wms",
+                url: "/geoserver/wms",
                 version: "1.1.1"
             },
             osm: {

--- a/openquakeplatform/openquakeplatform/proxy.py
+++ b/openquakeplatform/openquakeplatform/proxy.py
@@ -1,0 +1,34 @@
+import httplib2
+
+from django.conf import settings
+from django.http import HttpResponse
+
+from geonode.utils import ogc_server_settings
+
+
+def geoserver(request):
+    """
+    Simple proxy to access geoserver and avoid Same-domain Access
+    Control Policy restrictions
+    """
+    url = "".join([
+        ogc_server_settings.LOCATION,
+        request.get_full_path()[len("/geoserver/"):]])
+
+    headers = {}
+    if settings.SESSION_COOKIE_NAME in request.COOKIES:
+        headers["Cookie"] = request.META["HTTP_COOKIE"]
+
+    if request.method in ("POST", "PUT") and "CONTENT_TYPE" in request.META:
+        headers["Content-Type"] = request.META["CONTENT_TYPE"]
+
+    http = httplib2.Http()
+    response, content = http.request(
+        url, request.method,
+        body=request.raw_post_data or None,
+        headers=headers)
+
+    return HttpResponse(
+        content=content,
+        status=response.status,
+        mimetype=response.get("content-type", "text/plain"))

--- a/openquakeplatform/openquakeplatform/static/js/explore_leaflet.js
+++ b/openquakeplatform/openquakeplatform/static/js/explore_leaflet.js
@@ -172,7 +172,7 @@ var startExploreApp = function() {
     // Get Geoserver info with GetCapabilities
     $.ajax({
         type: "GET",
-             url: "/proxy?url=" + encodeURIComponent("http://localhost:8080/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities&TILED=true&VERSION=1.1.1"),
+             url: "/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities&TILED=true&VERSION=1.1.1",
         dataType: "xml",
         success: function(xmlDoc) {
             var layerNames = $(xmlDoc).find('Layer > Name');

--- a/openquakeplatform/openquakeplatform/urls.py
+++ b/openquakeplatform/openquakeplatform/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, patterns, url
 from django.conf import settings
+from django.http import HttpResponseBadRequest
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.conf.urls.static import static
 from geonode.sitemap import LayerSitemap, MapSitemap
@@ -24,7 +25,13 @@ sitemaps = {
     "map": MapSitemap
 }
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
+
+    # disable open proxy provided by geonode
+    url(r'^proxy/$', lambda _r: HttpResponseBadRequest("Proxy disabled")),
+    url(r'^geoserver/', 'openquakeplatform.proxy.geoserver',
+        name="geoserver"),
 
     url(r'^isc_viewer/$', TemplateView.as_view(
         template_name="isc_viewer.html"), name='isc_viewer'),
@@ -46,10 +53,14 @@ urlpatterns = patterns('',
     (r'^icebox/', include('openquakeplatform.icebox.urls')),
 
     # Static pages
-    url(r'^$', 'geonode.views.index', {'template': 'site_index.html'}, name='home'),
-    url(r'^help/$', TemplateView.as_view(template_name='help.html'), name='help'),
-    url(r'^developer/$', TemplateView.as_view(template_name='developer.html'), name='developer'),
-    url(r'^about/$', TemplateView.as_view(template_name='about.html'), name='about'),
+    url(r'^$', 'geonode.views.index',
+        {'template': 'site_index.html'}, name='home'),
+    url(r'^help/$',
+        TemplateView.as_view(template_name='help.html'), name='help'),
+    url(r'^developer/$',
+        TemplateView.as_view(template_name='developer.html'), name='developer'),
+    url(r'^about/$',
+        TemplateView.as_view(template_name='about.html'), name='about'),
 
     # Layer views
     (r'^layers/', include('geonode.layers.urls')),
@@ -79,16 +90,19 @@ urlpatterns = patterns('',
 
     # Accounts
     url(r'^account/ajax_login$', 'geonode.views.ajax_login',
-                                       name='account_ajax_login'),
+        name='account_ajax_login'),
     url(r'^account/ajax_lookup$', 'geonode.views.ajax_lookup',
-                                       name='account_ajax_lookup'),
+        name='account_ajax_lookup'),
 
     # Meta
-    url(r'^lang\.js$', TemplateView.as_view(template_name='lang.js', content_type='text/javascript'), name='lang'),
+    url(r'^lang\.js$',
+        TemplateView.as_view(
+            template_name='lang.js', content_type='text/javascript'),
+        name='lang'),
     url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog',
-                                  js_info_dict, name='jscat'),
+        js_info_dict, name='jscat'),
     url(r'^sitemap\.xml$', 'django.contrib.sitemaps.views.sitemap',
-                                  {'sitemaps': sitemaps}, name='sitemap'),
+        {'sitemaps': sitemaps}, name='sitemap'),
     (r'^i18n/', include('django.conf.urls.i18n')),
     (r'^admin/', include(admin.site.urls)),
 
@@ -96,7 +110,8 @@ urlpatterns = patterns('',
 
 #Documents views
 if settings.DOCUMENTS_APP:
-    urlpatterns += patterns('',
+    urlpatterns += patterns(
+        '',
         (r'^documents/', include('geonode.documents.urls')),
     )
 


### PR DESCRIPTION
Geonode setup an open proxy mainly to let the js application communicate with geoserver.

See https://bugs.launchpad.net/oq-platform/+bug/1224362.

This pull request implements a simple proxy which allows the js app to communicate **only** with geoserver.
