### PR TITLE
Dialog "close" button style bug

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/calculate.js
+++ b/openquakeplatform/openquakeplatform/static/js/calculate.js
@@ -43,7 +43,9 @@ var startApp = function() {
     var showDialog = function(divTarget, title, content, options) {
         $(divTarget).empty();
         if (options === undefined) {
-            options = {};
+            options = {
+                dialogClass: ''
+            };
         }
         options.modal = true;
         options.title = title;


### PR DESCRIPTION
Fixes a bug where, if you load a calculation, the dialog gets set such
that the close button (the [x] in the upper right) is hidden. This is
fine for the "Loading..." dialog, but it's a problem because after that
the style gets applied to the "Run calculation" dialogs.

This patch ensures that the styling is reset.
