### PR TITLE
Create templates folder before cp

### DIFF
--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -166,6 +166,7 @@ def start():
 def stop():
     local('paver stop')
 
+
 def test():
     local('./run_tests.sh -v --with-coverage '
           '--cover-package=openquakeplatform')


### PR DESCRIPTION
In the fabfile we need to create the geoserver/data/templates/ folder before the cp command
