### PR TITLE
Fix bug in the creation of the callback_url

### DIFF
--- a/openquakeplatform/openquakeplatform/icebox/views.py
+++ b/openquakeplatform/openquakeplatform/icebox/views.py
@@ -86,7 +86,7 @@ class CalculationsView(JSONResponseMixin, generic.list.ListView):
                 data=dict(
                     database=settings.OQ_ENGINE_SERVER_DATABASE,
                     callback_url="%s%s" % (
-                        settings.SITEURL[:-1], reverse(
+                        settings.SITEURL.rstrip("/"), reverse(
                         "calculation", args=(calculation.pk,))),
                     foreign_calculation_id=calculation.pk,
                     # Risk only


### PR DESCRIPTION
Fix bug in the creation of the callback_url, using rstrip("/") to remove ending slashes if present in SITEURL, instead of removing the last character from it.
