### PR TITLE
Forward the HTTP_HOST through our development proxy for GeoServer

### DIFF
--- a/openquakeplatform/openquakeplatform/proxy.py
+++ b/openquakeplatform/openquakeplatform/proxy.py
@@ -26,6 +26,8 @@ def _make_request(request, url):
     if request.method in ("POST", "PUT") and "CONTENT_TYPE" in request.META:
         headers["Content-Type"] = request.META["CONTENT_TYPE"]
 
+    headers["Host"] = request.META["HTTP_HOST"]
+
     http = httplib2.Http()
     http.add_credentials(*(ogc_server_settings.credentials))
     response, content = http.request(


### PR DESCRIPTION
Forward the HTTP_HOST through our development proxy for GeoServer, so it will work also if the platform is not on localhost
