### PR TITLE
Sync urls.py with upstream

### DIFF
--- a/openquakeplatform/openquakeplatform/urls.py
+++ b/openquakeplatform/openquakeplatform/urls.py
@@ -158,7 +158,7 @@ urlpatterns = patterns('',
     )
 
 #Documents views
-if settings.DOCUMENTS_APP:
+if 'geonode.documents' in settings.INSTALLED_APPS:
     urlpatterns += patterns('',
         (r'^documents/', include('geonode.documents.urls')),
     )


### PR DESCRIPTION
This PR will sync our `urls.py` with the upstream GeoNode 2.0.

No re-factoring has been made yet since we'll change the structure of the platform using maps instead of custom applications, and because the templates need a complete re-factoring anyway.

The only major changes is the removal of

``` python
    # disable open proxy provided by geonode
    #    url(r'^proxy/$', 'openquakeplatform.proxy.fake_proxy',),
    url(r'^geoserver/', 'openquakeplatform.proxy.geoserver',
        name="geoserver"),
```

since now, with GeoNode 2.0, the forward proxy is implemented by GeoNode itself and it doesn't rely on Apache anymore (still used for the reverse).

Manually tested on dev (using fabfile installation) and production.
