### PR TITLE
Removes non-ascii symbols to avoid issues on some system configs

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -240,7 +240,7 @@ with open('$GEM_LOCAL_SETTINGS', 'w') as fh:
                                    hazard_calc_addr='${gem_hazard_calc_addr}',
                                    risk_calc_addr='${gem_risk_calc_addr}',
                                    oq_engserv_key='${gem_oq_engserv_key}',
-                                   oq_secret_key=''.join(random.choice(string.ascii_letters + string.digits + '%$&()=+-|#@') for _ in range(50)),
+                                   oq_secret_key=''.join(random.choice(string.ascii_letters + string.digits + '%$&()=+-|#@?') for _ in range(50)),
                                    mediaroot='/var/www/openquake/platform/uploaded',
                                    staticroot='/var/www/openquake/platform/static/'))"
 }

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -56,7 +56,7 @@ def bootstrap(db_name='oqplatform', db_user='oqplatform',
     local("which xmlstarlet")
 
     oq_secret_key=''.join(random.choice(string.ascii_letters + string.digits +
-    '%$&()=+-|#@') for _ in range(50))
+    '%$&()=+-|#@?') for _ in range(50))
 
     baseenv(db_name=db_name, db_user=db_user, db_pass=db_pass,
             host=host, hazard_calc_addr=hazard_calc_addr,


### PR DESCRIPTION
This PR will remove some non ascii symbols (£ and §) from the set used for the secret key generation since they are causing troubles on some systems (without a unicode environment) when fab is used.
