### PR TITLE
Help text for custom fields

### DIFF
--- a/openquakeplatform/openquakeplatform/vulnerability/models.py
+++ b/openquakeplatform/openquakeplatform/vulnerability/models.py
@@ -27,20 +27,13 @@ from commons import (SemicolonSeparatedFloatFormField,
 from django.core.validators import MinValueValidator, MaxValueValidator
 
 
-SSFF_HELP_TXT = 'Enter semicolon-separated floats (e.g. 4.5;3;2.2)'
-SSSF_HELP_TXT = 'Enter semicolon-separated strings (e.g. first;second;third)'
-BFF_HELP_TXT = ('Enter rows of semicolon-separated floats '
-                '(e.g. 4.5;3;2.2 <Enter> 3.1;1;4 <Enter> '
-                '6.2;5.3;1.1)')
-
-
 class SemicolonSeparatedFloatField(models.CharField):
     description = "Semicolon-separated floats"
 
     __metaclass__ = models.SubfieldBase
 
     def formfield(self, form_class=SemicolonSeparatedFloatFormField, **kwargs):
-        help_text = SSFF_HELP_TXT
+        help_text = 'Enter semicolon-separated floats (e.g. 4.5;3;2.2)'
         if self.help_text:
             help_text += '. ' + self.help_text
         defaults = {
@@ -76,7 +69,8 @@ class SemicolonSeparatedStringField(models.CharField):
 
     def formfield(self,
                   form_class=SemicolonSeparatedStringFormField, **kwargs):
-        help_text = SSSF_HELP_TXT
+        help_text = ('Enter semicolon-separated strings '
+                     '(e.g. first;second;third)')
         if self.help_text:
             help_text += '. ' + self.help_text
         defaults = {
@@ -95,7 +89,9 @@ class BidimensionalFloatField(models.TextField):
     __metaclass__ = models.SubfieldBase
 
     def formfield(self, form_class=BidimensionalFloatFormField, **kwargs):
-        help_text = BFF_HELP_TXT
+        help_text = ('Enter rows of semicolon-separated floats '
+                     '(e.g. 4.5;3;2.2 <Enter> 3.1;1;4 <Enter> '
+                     '6.2;5.3;1.1)')
         if self.help_text:
             help_text += '. ' + self.help_text
         defaults = {


### PR DESCRIPTION
Concatenate the help_text used in the models with the default help_text used by custom fields (custom fields side);
implement missing validations for FuncDistrDTLDiscr fields
