### PR TITLE
Fix filters by "intensity measure type" and "damage scale"

### DIFF
--- a/openquakeplatform/openquakeplatform/vulnerability/views.py
+++ b/openquakeplatform/openquakeplatform/vulnerability/views.py
@@ -55,38 +55,38 @@ def list_entries(request, **kwargs):
     region = request.POST.get('region')
     if category:
         geninfo = geninfo.filter(category=category)
-    if type_of_assessment:
-        geninfo = geninfo.filter(type_of_assessment=type_of_assessment)
+    geninfo = geninfo.filter(type_of_assessment=type_of_assessment)
+    if type_of_assessment == TA.FRAGILITY:
         if method_of_estimation:
-            if type_of_assessment == TA.FRAGILITY:
-                geninfo = geninfo.filter(
-                    fragility_func__method_of_estimation=method_of_estimation)
-                if intensity_measure_type:
-                    geninfo = geninfo.filter(
-                        fragility_func__predictor_var__intensity_measure_type=
-                        intensity_measure_type)
-                if damage_scale:
-                    geninfo = geninfo.filter(
-                        fragility_func__damage_scale=damage_scale)
-            elif type_of_assessment == TA.VULNERABILITY:
-                geninfo = geninfo.filter(
-                    vulnerability_func__method_of_estimation=
-                    method_of_estimation)
-                if intensity_measure_type:
-                    geninfo = geninfo.filter(
-                        vulnerability_func__predictor_var__intensity_measure_type=
-                        intensity_measure_type)
-            elif type_of_assessment == TA.DAMAGE_TO_LOSS:
-                geninfo = geninfo.filter(
-                    damage_to_loss_func__method_of_estimation=
-                    method_of_estimation)
-                if damage_scale:
-                    geninfo = geninfo.filter(
-                        damage_to_loss_func__damage_scale=damage_scale)
-            elif type_of_assessment == TA.CAPACITY_CURVE:
-                geninfo = geninfo.filter(
-                    capacity_curve_func__method_of_estimation=
-                    method_of_estimation)
+            geninfo = geninfo.filter(
+                fragility_func__method_of_estimation=method_of_estimation)
+        if intensity_measure_type:
+            geninfo = geninfo.filter(
+                fragility_func__predictor_var__intensity_measure_type=
+                intensity_measure_type)
+        if damage_scale:
+            geninfo = geninfo.filter(
+                fragility_func__damage_scale=damage_scale)
+    elif type_of_assessment == TA.VULNERABILITY:
+        if method_of_estimation:
+            geninfo = geninfo.filter(
+                vulnerability_func__method_of_estimation=method_of_estimation)
+        if intensity_measure_type:
+            geninfo = geninfo.filter(
+                vulnerability_func__predictor_var__intensity_measure_type=
+                intensity_measure_type)
+    elif type_of_assessment == TA.DAMAGE_TO_LOSS:
+        if method_of_estimation:
+            geninfo = geninfo.filter(
+                damage_to_loss_func__method_of_estimation=method_of_estimation)
+        if damage_scale:
+            geninfo = geninfo.filter(
+                damage_to_loss_func__damage_scale=damage_scale)
+    elif type_of_assessment == TA.CAPACITY_CURVE:
+        if method_of_estimation:
+            geninfo = geninfo.filter(
+                capacity_curve_func__method_of_estimation=
+                method_of_estimation)
     if material:
         geninfo = geninfo.filter(material=material)
     if llrs:


### PR DESCRIPTION
There was a bug in the conditions checking the presence of the POST parameters, so the workflow did not filter by "intensity measure type" and "damage scale" when "method of estimation" parameter was not set.
