### PR TITLE
Make TileStream GXP source protocol scheme agnostic

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/TileStreamSource.js
+++ b/openquakeplatform/openquakeplatform/static/js/TileStreamSource.js
@@ -102,7 +102,7 @@ var tilestreamPlugin = {
 
         var layers = new Array();
 
-        $.getJSON('http://tilestream.openquake.org/api/v1/Tileset',
+        $.getJSON('//tilestream.openquake.org/api/v1/Tileset',
         function(json) {
             for (var i=0; i < json.length; i++) {
                 // Get the tile name and zoom level from the tilestream API


### PR DESCRIPTION
This PR makes the TileStream URL in gxp protocol scheme agnostic.

We should find a better way to manage the TileStream URL which is hardcoded in many parts of the platform.
