### PR TITLE
Get only distinct functions while filtering by region. Allow searching countries by incomlpete name.

### DIFF
--- a/openquakeplatform/openquakeplatform/vulnerability/views.py
+++ b/openquakeplatform/openquakeplatform/vulnerability/views.py
@@ -98,9 +98,10 @@ def list_entries(request, **kwargs):
         geninfo = geninfo.filter(authors__icontains=author)
     if country:
         geninfo = geninfo.filter(
-            geo_applicability__countries__name__iexact=country)
+            geo_applicability__countries__name__icontains=country)
     if region:
-        geninfo = geninfo.filter(geo_applicability__countries__region=region)
+        geninfo = geninfo.filter(
+            geo_applicability__countries__region=region).distinct()
 
     # paginator = Paginator(geninfo, 2)
 


### PR DESCRIPTION
The previous behavior was that when a function has a geographical applicability with many countries in a region, if you filtered by that region you had the function listed many times instead of only once. Now only distinct functions are shown.

The text field for searching by country name now gives you the possibility to select by incomplete country name (for instance select all countries that end with stan)
