### PR TITLE
For FF continuous, minimum_im and maximum_im are now mandatory in the DB, so we don't need to set their values in case they are undefined

### DIFF
--- a/openquakeplatform/openquakeplatform/vulnerability/static/vulnerability/js/fragility_curves.js
+++ b/openquakeplatform/openquakeplatform/vulnerability/static/vulnerability/js/fragility_curves.js
@@ -480,16 +480,8 @@ if(funcDistrType == "Continuous") {
     meanArray = meanArray.split(";");
 
     var lastMean = meanArray.length-1;
-    if (gl.fields.fragility_func.fields.predictor_var.fields.minimum_im == undefined) {
-        var min = meanArray[0] / 4.0
-    } else {
-        var min = gl.fields.fragility_func.fields.predictor_var.fields.minimum_im;
-    }
-    if (gl.fields.fragility_func.fields.predictor_var.fields.maximum_im == undefined) {
-        var max = (2 * meanArray[lastMean]);
-    } else {
-        var max = gl.fields.fragility_func.fields.predictor_var.fields.maximum_im;
-    }
+    var min = gl.fields.fragility_func.fields.predictor_var.fields.minimum_im;
+    var max = gl.fields.fragility_func.fields.predictor_var.fields.maximum_im;
     
     var inc = ((max - min) / 100);
     var limitStatesArray =  gl.fields.fragility_func.fields.limit_states_desc;


### PR DESCRIPTION
For continuous fragility functions, the min and max intensity measures are not mandatory.
The case in which the max is undefined was already handled by the tool.
With this PR, in case minimum_im is undefined, it is set to 1/4 of the smallest mean value (mean values are mandatory)
