### PR TITLE
Change GEOSERVER path to be relative

### DIFF
--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -314,7 +314,7 @@ MIDDLEWARE_CLASSES = (
 MAP_BASELAYERS = [{
     "source": {
         "ptype": "gxp_wmscsource",
-        "url": GEOSERVER_URL + "wms",
+        "url": OGC_SERVER['default']['PUBLIC_LOCATION'] + "wms",
         "restUrl": "/gs/rest"
      }
   },{


### PR DESCRIPTION
I discovered that layers are stored in GeoNode DB with the source full hostname hardcoded. This is causing troubles when moving an installation under a new hostname (i.e. moving from staging to production):

``` sql
oqplatform=# SELECT id, map_id, ows_url FROM maps_maplayer WHERE ows_url IS NOT NULL OR ows_url != '';
 id | map_id |                       ows_url                        
----+--------+------------------------------------------------------
 20 |     30 | https://platform-staging.openquake.org/geoserver/wms
 21 |     30 | https://platform-staging.openquake.org/geoserver/wms
 41 |     38 | https://platform-staging.openquake.org/geoserver/wms
 42 |     38 | https://platform-staging.openquake.org/geoserver/wms
 50 |     39 | https://platform-staging.openquake.org/geoserver/wms
 51 |     39 | https://platform-staging.openquake.org/geoserver/wms
 58 |     40 | https://platform-staging.openquake.org/geoserver/wms
 59 |     40 | https://platform-staging.openquake.org/geoserver/wms
 68 |     41 | https://platform-staging.openquake.org/geoserver/wms
 76 |     42 | https://platform-staging.openquake.org/geoserver/wms
 77 |     42 | https://platform-staging.openquake.org/geoserver/wms
 99 |     50 | https://platform-staging.openquake.org/geoserver/wms
(12 rows)
```

This PR should makes the `ows_url(s)` relative (`/geoserver/wms`) and not absolute. Before merging this must be tested intensively in all scenarios (dev, prod, prod+https).
