### PR TITLE
Add 'Remove' button also for queued jobs

### DIFF
--- a/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
+++ b/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
@@ -90,7 +90,7 @@ Calculate - {{block.super}}
             <a href="/maps/<%= calc.get('map') %>" class="btn btn-success">Open</a>
           <% } %>
 
-          <% if(calc.get('status') == 'complete' || calc.get('status') == 'failed') { %>
+          <% if(calc.get('status') == 'complete' || calc.get('status') == 'failed' || calc.get('status') == 'queued') { %>
             <% if(calc.get('status') == 'failed') { %>
               <% traceback = calc.get('einfo') %>
               <button class="btn" onclick="popup_error_traceback(traceback)">Traceback</button>


### PR DESCRIPTION
This simply adds the "Remove" button also for queued jobs. It still doesn't cover all the cases (i.e. when a job fails with the `ERROR Unknow key oq-platform in PLATFORM_DATABASES; you forgot to set local_settings.py` exception).

See this example
![screen shot 2014-09-05 at 17 46 23](https://cloud.githubusercontent.com/assets/1818657/4167502/fa55ebd6-3513-11e4-9f1e-556f30be4082.png)
