### PR TITLE
Reintroduce GeoServer development proxy but only in dev mode

### DIFF
--- a/openquakeplatform/openquakeplatform/urls.py
+++ b/openquakeplatform/openquakeplatform/urls.py
@@ -170,7 +170,7 @@ if 'geonode.documents' in settings.INSTALLED_APPS:
     )
 # Enable internal geoserver proxy in development mode.
 # In production it must be done by Apache/Nginx, not by Django
-if settings.debug:
+if settings.DEBUG:
     urlpatterns += patterns('',
         url(r'^geoserver/', 'openquakeplatform.proxy.geoserver',
             name="geoserver"),


### PR DESCRIPTION
This simplifies development under certain conditions. Since it could hide problems and is not for production,  it must be switched off easily: in production `DEBUG` is (and must be) always `False`, so it's activated only when `DEBUG` is `True`.
