### PR TITLE
ecd: check image associated to an event before try to show them

### DIFF
--- a/openquakeplatform/openquakeplatform/gemecdwebsite/eventdetails/eventdetails.py
+++ b/openquakeplatform/openquakeplatform/gemecdwebsite/eventdetails/eventdetails.py
@@ -1,5 +1,6 @@
 __author__ = 'Simon Ruffle, CAR'
 
+import os
 import platform
 from openquakeplatform.weblib.baseclasses.pagebase import Pagebase
 import urllib2
@@ -8,6 +9,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from datetime import datetime
 from django.forms import ModelForm
+from openquakeplatform.settings import STATICFILES_DIRS
 from openquakeplatform.econd.event_models import Event
 from openquakeplatform.econd.models import Study, Location, Locations, Inventoryclass, Surveyvalue, Damagelevel, Casualtylevel
 from openquakeplatform.econd.sql_views import LocationsQuick
@@ -239,7 +241,15 @@ class EventDetailsPage (Pagebase):
         # set up the filter string for returns
         self.page_context['filterstring'] = '?&studyid=' + str(studyid) + '&f_b=' + str(filter_buildings) + '&f_c=' + str(filter_casualty) + '&f_i=' + str(filter_infrastructure) + '&f_p=' + str(filter_photos) + '&f_s=' + str(filter_socioeconomic) + '&all=' + str(filter_all)
 
-        self.page_context['iconicimage'] = 'event' + str(eventid) + '.jpg'
+        # iconic image
+        fname = 'event' + str(eventid) + '.jpg'
+        for dir in STATICFILES_DIRS:
+            fullname = dir + '/gemecdeventicons/' + fname
+            if os.path.exists(fullname):
+                self.page_context['iconicimage'] = fname
+                break
+        else:
+            self.page_context['iconicimage'] = ''
 
         ###############
         # GET

--- a/openquakeplatform/openquakeplatform/gemecdwebsite/eventdetails/templates/eventdetails.html
+++ b/openquakeplatform/openquakeplatform/gemecdwebsite/eventdetails/templates/eventdetails.html
@@ -57,7 +57,9 @@
                     <div class="infocontainerwide">
                         <h1>{{ paneltitle }}</h1>
                         <div class="overview">{% formviewastable field_structure=eventoverviewfields %}</div>
-                        <img class="eventicon" src="{{ STATIC_URL }}gemecdeventicons/{{ iconicimage }}" title="{{ paneltitle }}"/>
+                        {% if iconicimage != "" %}
+                            <img class="eventicon" src="{{ STATIC_URL }}gemecdeventicons/{{ iconicimage }}" title="{{ paneltitle }}"/>
+                        {% endif %}
                     </div>
 
                     <div class="infocontainerwide">

--- a/openquakeplatform/openquakeplatform/gemecdwebsite/eventoverview/eventoverview.py
+++ b/openquakeplatform/openquakeplatform/gemecdwebsite/eventoverview/eventoverview.py
@@ -1,5 +1,6 @@
 __author__ = 'Simon Ruffle, CAR'
 
+import os
 import platform
 from openquakeplatform.weblib.baseclasses.pagebase import Pagebase
 import urllib2
@@ -12,6 +13,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.forms import ModelForm
 from django.db.models import get_model
 from openquakeplatform import settings
+from openquakeplatform.settings import STATICFILES_DIRS
 from openquakeplatform.econd.models import EventsQuick, LocationsForJSON, LocationsForJSONAggregated,Study
 from openquakeplatform.econd.event_models import Event
 from openquakeplatform.econd.sql_views import LocationsQuick
@@ -369,7 +371,14 @@ class EventOverview (Pagebase):
         self.page_context['eventform'] = eventForm # for editing
 
         # iconic image
-        self.page_context['iconicimage'] = 'event' + str(eventid) + '.jpg'
+        fname = 'event' + str(eventid) + '.jpg'
+        for dir in STATICFILES_DIRS:
+            fullname = dir + '/gemecdeventicons/' + fname
+            if os.path.exists(fullname):
+                self.page_context['iconicimage'] = fname
+                break
+        else:
+            self.page_context['iconicimage'] = ''
 
         ###############
         # POST

--- a/openquakeplatform/openquakeplatform/gemecdwebsite/eventoverview/templates/eventoverview.html
+++ b/openquakeplatform/openquakeplatform/gemecdwebsite/eventoverview/templates/eventoverview.html
@@ -6,7 +6,9 @@
             <div id="panelcontainer">
                 <div id="backlink">{{ page_backlink|safe }}</div>
                 <h1>{{ paneltitle }}</h1>
-                    <img class="eventicon" src="{{ STATIC_URL }}gemecdeventicons/{{ iconicimage }}" title="{{ paneltitle }}"/>
+                {% if iconicimage != "" %}
+                <img class="eventicon" src="{{ STATIC_URL }}gemecdeventicons/{{ iconicimage }}" title="{{ paneltitle }}"/>
+                {% endif %}
 
                     <a class="moredetailslink" href="/ecd/eventdetails/{{ eventid }}{{ filterstring }}">Full event details &raquo;</a>
 


### PR DESCRIPTION
Show iconic event image if related file exists only.
