### PR TITLE
In qrs fieldsets include the 'owner' field

### DIFF
--- a/openquakeplatform/openquakeplatform/vulnerability/admin.py
+++ b/openquakeplatform/openquakeplatform/vulnerability/admin.py
@@ -496,14 +496,15 @@ class NestedModelAdminCrossChecked(NestedModelAdmin):
 
 
 qrs_analytical_fieldsets = (
+    (None, {
+        'fields': ('owner',)
+    }),
     ('Data quality', {
-        'classes': ('collapse',),
         'fields': ('structural_details',
                    'model_completeness',
                    'seismic_demand', )
     }),
     ('Rationality', {
-        'classes': ('collapse',),
         'fields': ('analysis_type',
                    'limit_states_def',
                    'sampling_method',
@@ -511,12 +512,10 @@ qrs_analytical_fieldsets = (
                    'uncertainties_treatment')
     }),
     ('Documentation quality', {
-        'classes': ('collapse',),
         'fields': ('documentation_quality',
                    'documentation_type', )
     }),
     ('Representativeness', {
-        'classes': ('collapse',),
         'fields': ('typology_repr',
                    'site_specific',
                    'hazard_model', )
@@ -525,27 +524,26 @@ qrs_analytical_fieldsets = (
 
 
 qrs_empirical_fieldsets = (
+    (None, {
+        'fields': ('owner',)
+    }),
     ('Data quality', {
-        'classes': ('collapse',),
         'fields': ('data_quantity',
                    'constrained_categories',
                    'excitation_observation',
                    'damage_loss_observation',)
     }),
     ('Rationality', {
-        'classes': ('collapse',),
         'fields': ('hindcasting',
                    'cross_validation',
                    'first_principles',
                    'uncertainties_treatment',)
     }),
     ('Documentation quality', {
-        'classes': ('collapse',),
         'fields': ('documentation_quality',
                    'documentation_type', )
     }),
     ('Representativeness', {
-        'classes': ('collapse',),
         'fields': ('representativeness', ),
     }),
 )


### PR DESCRIPTION
Since the fieldsets for `qrs_analytical` and `qrs_empirical` are explicitly defined in `admin.py`, we need to explicitly include the field `owner` in the fieldsets.
This PR also removes the "show-hide" behavior of the subsections (we will need to decide if we want to add a custom CSS class instead of `collapse` or if the current behavior is fine)
