### PR TITLE
Setup local_settings.py for user registration

### DIFF
--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -376,7 +376,7 @@ AUTH_EXEMPT_URLS = ('/account/signup/',
 # must be verified by the user.
 # ACCOUNT_ACTIVATION_DAYS = 1
 
-# A valid mailserver must be configured to make open registration work
+# A valid mailserver must be configured to make open registration work.
 # EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 # EMAIL_HOST = 'localhost'
 # EMAIL_PORT = 25


### PR DESCRIPTION
These modification are needed for an open user registration:
- `/account/signup/` must be white-listed otherwise it cannot be seen by unauthenticated users
- `REGISTRATION_OPEN` must be set to `True`
- with `ACCOUNT_ACTIVATION_DAYS` you can define number of days in which account will be left active without a successful activation 

Be careful, by default there's no admin validation mechanism on new accounts. New accounts are automatically enabled. They must be validated by users using link in the confirmation email within `ACCOUNT_ACTIVATION_DAYS` days. I don't like this approach. I would like to have the email validated _before_ the account is activated, but this is the default (and only) way in GeoNode.

See: http://geonode.readthedocs.org/en/latest/tutorials/users/accounts/registration.html and https://django-registration.readthedocs.org/en/latest/default-backend.html

Also a working mailserver must be set.
