### PR TITLE
Fixed some URIs of the calculate tab

### DIFF
--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -112,8 +112,8 @@ LOCALE_PATHS = (
 )
 
 OQ_ENGINE_SERVER_URLS = {
-    'run_hazard_calc_form': '%(hazard_calc_addr)s/v1/calc/hazard/run',  # i.e. : 'http://oq-platform:8800'
-    'run_risk_calc_form': '%(risk_calc_addr)s/v1/calc/risk/run',        # i.e. : 'http://oq-platform:8800'
+    'run_hazard_calc_form': '%(hazard_calc_addr)s/v1/calc/run',  # i.e. : 'http://oq-platform:8800'
+    'run_risk_calc_form': '%(risk_calc_addr)s/v1/calc/run',        # i.e. : 'http://oq-platform:8800'
 }
 
 THIRD_PARTY_URLS = {


### PR DESCRIPTION
The hazard/risk unification in https://github.com/gem/oq-engine/pull/1594 involves the following URI changes:

/v1/calc/(hazard|risk)/[id] -> /v1/calc/[id]
/v1/calc/(hazard|risk)/[id]/results -> /v1/calc/[id]/results
/v1/calc/(hazard|risk)/result/[id] -> /v1/calc/result/[id]
/v1/calc/(hazard|risk)/run -> /v1/calc/run
