### PR TITLE
Wrong geonode-user-accounts package name

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -460,7 +460,7 @@ oq_platform_install () {
     apt-get install -y python-software-properties
     add-apt-repository ppa:openquake-automatic-team/latest-master
     apt-get update
-    apt-get install -y geonode-user-accounts
+    apt-get install -y python-geonode-user-accounts
     add-apt-repository -y ppa:geonode/release
     apt-get update
     apt-get install -y geonode


### PR DESCRIPTION
The package name in `deploy.sh` was wrong.
