### PR TITLE
Move site name setup after syncdb and change default user

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -545,10 +545,6 @@ oq_platform_install () {
     fi
 
     #
-    # Update Django 'sites' with real hostname
-    DJANGO_SETTINGS_MODULE='openquakeplatform.settings' python -c "from django.contrib.sites.models import Site; from openquakeplatform import settings; mysite = Site.objects.all()[0]; mysite.domain = settings.SITEURL; mysite.name = settings.SITENAME; mysite.save()"
-
-    #
     #  database population (fixtures)
     for app in "${GEM_APP_LIST[@]}"; do
         if function_exists "${app}_fixtureupdate"; then
@@ -568,8 +564,12 @@ oq_platform_install () {
 
     openquakeplatform collectstatic --noinput
 
+    #
+    # Update Django 'sites' with real hostname
+    DJANGO_SETTINGS_MODULE='openquakeplatform.settings' python -c "from django.contrib.sites.models import Site; from openquakeplatform import settings; mysite = Site.objects.all()[0]; mysite.domain = settings.SITEURL; mysite.name = settings.SITENAME; mysite.save()"
+
     if [ "$GEM_IS_INSTALL" == "y" ]; then
-        openquakeplatform createsuperuser --username=the_user --email=the_mail@openquake.org --noinput
+        openquakeplatform createsuperuser --username=admin --email=the_mail@openquake.org --noinput
     fi
 
     service apache2 restart


### PR DESCRIPTION
- The site name setup must be after the syncdb
- The first superuser must be `admin` to be compliant with the new fixture set
