### PR TITLE
Make sure local apt cache is up-to-date before installing anything

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -457,6 +457,7 @@ oq_platform_install () {
         service tomcat7 start                      || true
     fi
 
+    apt-get update
     apt-get install -y python-software-properties
     add-apt-repository ppa:openquake-automatic-team/latest-master
     add-apt-repository -y ppa:geonode/release


### PR DESCRIPTION
This makes sure that the `apt-get install -y python-software-properties` will not fail due outdated local apt cache.
