### PR TITLE
Reduce verbosity of oq-gs-builder.sh

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 if [ $GEM_SET_DEBUG ]; then
     set -x
 fi

--- a/openquakeplatform/openquakeplatform/bin/oq-gs-builder.sh
+++ b/openquakeplatform/openquakeplatform/bin/oq-gs-builder.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-#set -x
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 set -e
 # export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
 export PS4='+${LINENO}:${FUNCNAME[0]}: '


### PR DESCRIPTION
The `oq-gs-builder.sh` produces lot of output which sometime make it hard to read.
