### PR TITLE
Fix wrong url in /admin

### DIFF
--- a/openquakeplatform/openquakeplatform/icebox/urls.py
+++ b/openquakeplatform/openquakeplatform/icebox/urls.py
@@ -25,7 +25,7 @@ from openquakeplatform.icebox import views
 
 
 urlpatterns = patterns(
-    'geonode.icebox.views',
+    'openquakeplatform.icebox.views',
     url(r'^$', login_required(TemplateView.as_view(
         template_name="icebox.html")), name="icebox"),
     url(r'^calculations$', login_required(views.CalculationsView.as_view()),

--- a/openquakeplatform/openquakeplatform/svir/urls.py
+++ b/openquakeplatform/openquakeplatform/svir/urls.py
@@ -29,8 +29,7 @@ admin.autodiscover()
 
 
 urlpatterns = patterns(
-    'geonode.svir.views',
-    url(r'^admin/', include(admin.site.urls)),
+    'openquakeplatform.svir.views',
     url(r'^list_themes', list_themes),
     url(r'^list_subthemes_by_theme', list_subthemes_by_theme),
     url(r'^export_variables_info', export_variables_info),

--- a/openquakeplatform/openquakeplatform/world/urls.py
+++ b/openquakeplatform/openquakeplatform/world/urls.py
@@ -25,6 +25,5 @@ admin.autodiscover()
 
 
 urlpatterns = patterns(
-    'geonode.world.views',
-    url(r'^admin/', include(admin.site.urls)),
+    'openquakeplatform.world.views',
 )


### PR DESCRIPTION
The links under `/admin` are generated as `/world/admin` and `/svir/admin`. This PR fixes this issue.
