### PR TITLE
Change default permission for new uploads

### DIFF
--- a/openquakeplatform/openquakeplatform/templates/_permissions.html
+++ b/openquakeplatform/openquakeplatform/templates/_permissions.html
@@ -4,11 +4,11 @@
     <label class="control-label"><strong>{% trans "Who can view and download this data?" %}</strong></label>
     <div class="controls">
       <label class="radio inline">
-        <input type="radio" name="viewmode" id="perms_view_anyone" value="ANYONE" checked="checked">
+        <input type="radio" name="viewmode" id="perms_view_anyone" value="ANYONE">
         {% trans "Anyone" %}
       </label>
       <label class="radio inline">
-        <input type="radio" name="viewmode" id="perms_view_registered" value="REGISTERED">
+        <input type="radio" name="viewmode" id="perms_view_registered" value="REGISTERED" checked="checked">
         {% trans "Any registered user" %}
       </label>
       <label class="radio inline">
@@ -21,21 +21,21 @@
     <label class="control-label"><strong>{% trans "Who can edit this data?" %}</strong></label>
     <div class="controls">
       <label class="radio">
-        <input type="radio" name="editmode" id="perms_edit_registered" value="REGISTERED" checked="checked">
+        <input type="radio" name="editmode" id="perms_edit_registered" value="REGISTERED">
         {% trans "Any registered user" %}
       </label>
       <label class="radio">
-        <input type="radio" name="editmode" id="perms_edit_list" value="LIST">
+        <input type="radio" name="editmode" id="perms_edit_list" value="LIST" checked="checked">
         {% trans "Only the following users:" %}
       </label>
-      <input type="text" name="editusers" class="user-select" id="perms_edit_editusers">
+      <input type="text" name="editusers" class="user-select" id="perms_edit_editusers" value="{{ request.user }}">
       </input>
     </div>
   </div>
   <div class="control-group">
     <label class="control-label"><strong>{% trans "Who can manage and edit this data?" %}</strong></label>
     <div class="controls">
-      <input type="text" name="manageusers" class="user-select" id="perms_edit_manageusers">
+      <input type="text" name="manageusers" class="user-select" id="perms_edit_manageusers" value="{{ request.user }}">
       </input>
     </div>
   </div>


### PR DESCRIPTION
Change permission form defaults (overriding GeoNode's `_permissions.html`) to:
- Anyone has an account can view
- Only owner can edit

This affects all the uploads using permissions (layers, documents).
