### PR TITLE
Revert GEOSERVER_URL to absolute URL, relative gives a 404 in GXP

### DIFF
--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -126,7 +126,7 @@ TILESTREAM_URL = '//tilestream.openquake.org'
 
 HELP_URL = 'http://www.globalquakemodel.org/openquake/support/documentation/platform'
 
-# The GEOSERVER_URL must be an absoulute URL to let GXP working correctly.
+# The GEOSERVER_URL must be an absolute URL to let GXP working correctly.
 # To produce fixture for maps to be installed during setup it must be set
 # to the '/geoserver/' relative path
 GEOSERVER_URL = SITEURL + 'geoserver/'

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -137,7 +137,7 @@ OGC_SERVER = {
     'default': {
         'BACKEND': 'geonode.geoserver',
          # Do not change the internal channel
-        'LOCATION': 'http://localhost:8080' + GEOSERVER_URL,
+        'LOCATION': 'http://localhost:8080/geoserver/',
         'PUBLIC_LOCATION': GEOSERVER_URL,
         'USER': 'admin',
         'PASSWORD': 'geoserver',

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -126,7 +126,7 @@ TILESTREAM_URL = '//tilestream.openquake.org'
 
 HELP_URL = 'http://www.globalquakemodel.org/openquake/support/documentation/platform'
 
-GEOSERVER_URL = '/geoserver/'
+GEOSERVER_URL = SITEURL + 'geoserver/'
 
 TEMPLATE_CONTEXT_PROCESSORS += (
     'openquakeplatform.utils.oq_context_processor',

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -126,6 +126,9 @@ TILESTREAM_URL = '//tilestream.openquake.org'
 
 HELP_URL = 'http://www.globalquakemodel.org/openquake/support/documentation/platform'
 
+# The GEOSERVER_URL must be an absoulute URL to let GXP working correctly.
+# To produce fixture for maps to be installed during setup it must be set
+# to the '/geoserver/' relative path
 GEOSERVER_URL = SITEURL + 'geoserver/'
 
 TEMPLATE_CONTEXT_PROCESSORS += (


### PR DESCRIPTION
Revert changes made in #217 because this configuration gives an 404 when a non superuser tries to add a layer to a map:

![screenshot from 2015-01-05 16 01 53](https://cloud.githubusercontent.com/assets/1818657/5614720/3969f624-94f4-11e4-9fc4-c0a9c3593707.png)

We need to take this revert into account when we change protocol and or hostname. A change in the platform urls will break all the maps. Probably it would be better to solve the issue in other ways.