### PR TITLE
Add support for Google Analytics using local_settings.py

### DIFF
--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -383,3 +383,5 @@ ICEBOX_MAX_SIZE_MB = 10
 ICEBOX_SEND_EMAIL = False
 
 AVATAR_GRAVATAR_DEFAULT = 'http://ftp.openquake.org/oq-platform/oq-avatar-40.png'
+
+GOOGLE_UA = False

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -384,4 +384,6 @@ ICEBOX_SEND_EMAIL = False
 
 AVATAR_GRAVATAR_DEFAULT = 'http://ftp.openquake.org/oq-platform/oq-avatar-40.png'
 
-GOOGLE_UA = False
+# Enable Google Analytics tracking code
+# You must provide a valid UA code
+# GOOGLE_UA = 'UA-********-*'

--- a/openquakeplatform/openquakeplatform/templates/site_base.html
+++ b/openquakeplatform/openquakeplatform/templates/site_base.html
@@ -132,4 +132,17 @@
         }});
       }
     </script>
+
+    {%if GOOGLE_UA %}
+    <script type="text/javascript">
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '{{ GOOGLE_UA }}', 'auto');
+      ga('send', 'pageview');
+    </script>
+    {% endif %}
+
 {% endblock extra_script %}

--- a/openquakeplatform/openquakeplatform/utils.py
+++ b/openquakeplatform/openquakeplatform/utils.py
@@ -1,7 +1,5 @@
-from django.views.generic import TemplateView
 from django.conf import settings
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
 
 SIGN_IN_REQUIRED = ('You must be signed into the OpenQuake Platform to use '
                     'this feature.')
@@ -13,11 +11,12 @@ class allowed_methods(object):
 
     def __call__(self, func):
         def wrapped(request):
-            if not request.method in self.methods:
+            if request.method not in self.methods:
                 return HttpResponse(status=405)
             else:
                 return func(request)
         return wrapped
+
 
 def oq_context_processor(request):
     """
@@ -36,6 +35,7 @@ def oq_context_processor(request):
         context['GOOGLE_UA'] = settings.GOOGLE_UA
 
     return context
+
 
 def sign_in_required(func):
     """

--- a/openquakeplatform/openquakeplatform/utils.py
+++ b/openquakeplatform/openquakeplatform/utils.py
@@ -32,6 +32,8 @@ def oq_context_processor(request):
     context['is_gem_experimental'] = settings.GEM_EXPERIMENTAL
     context['TILESTREAM_URL'] = settings.TILESTREAM_URL
     context['HELP_URL'] = settings.HELP_URL
+    if hasattr(settings, 'GOOGLE_UA'):
+        context['GOOGLE_UA'] = settings.GOOGLE_UA
 
     return context
 

--- a/openquakeplatform/openquakeplatform/utils.py
+++ b/openquakeplatform/openquakeplatform/utils.py
@@ -31,8 +31,7 @@ def oq_context_processor(request):
     context['is_gem_experimental'] = settings.GEM_EXPERIMENTAL
     context['TILESTREAM_URL'] = settings.TILESTREAM_URL
     context['HELP_URL'] = settings.HELP_URL
-    if hasattr(settings, 'GOOGLE_UA'):
-        context['GOOGLE_UA'] = settings.GOOGLE_UA
+    context['GOOGLE_UA'] = getattr(settings, 'GOOGLE_UA', False)
 
     return context
 


### PR DESCRIPTION
Code is enabled only when a `UA-*****` is provided through the `local_settings.py`.

The `GOOGLE_UA` in settings is not mandatory.