### PR TITLE
override the leaflet contorl layer labels override

### DIFF
--- a/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure-export.css
+++ b/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure-export.css
@@ -44,3 +44,7 @@
 label {
     display: inline !important
 }
+
+.leaflet-control-layers-overlays label {
+    display: block !important
+}


### PR DESCRIPTION
This PR resolves a small css conflict between the labels and the leaflet layer control labels.