### PR TITLE
Modify the data formatter

### DIFF
--- a/openquakeplatform/openquakeplatform/vulnerability/static/vulnerability/js/vulnerability_curves.js
+++ b/openquakeplatform/openquakeplatform/vulnerability/static/vulnerability/js/vulnerability_curves.js
@@ -927,6 +927,18 @@ function buildD3Chart(chartData) {
     var chartDataFilteredCopy = JSON.parse(JSON.stringify(chartDataFiltered));
 
     if (funcDistrType == "Discrete") {
+        // Check the greatest value in the y axis, and then modify the data formatter accordingly
+        var steps = [];
+        for (var b = 0; b < chartData.length; b++) {
+            steps.push(chartData[b][1]);
+        }
+
+        var theLastStep = steps[steps.length-1];
+
+        if ((theLastStep) < 0.2) {
+            formatter = d3.format(".2%");
+        }
+
         var maxy = "";
         maxy = chartDataFilteredCopy.pop();
         maxy = maxy[1];
@@ -944,10 +956,12 @@ function buildD3Chart(chartData) {
         .scale(x_scale)
         .tickFormat(function (d) { return d; })
         .orient("bottom");
+
     var yAxis = d3.svg.axis()
         .scale(y_scale)
         .orient("left")
         .tickFormat(formatter);
+
     var line = d3.svg.line()
         .x(function(d) {
             return x_scale(d[0]);
@@ -955,6 +969,7 @@ function buildD3Chart(chartData) {
         .y(function(d) {
             return y_scale(d[1]);
         });
+
     var svg = d3.select("#functionChart").append("svg")
         .attr("width", width + margin.left + margin.right)
         .attr("height", height + margin.top + margin.bottom)


### PR DESCRIPTION
In the case that a discrete Vulnerability function has y-axis labels less than 0.2 we need to modify the data formatter.