### PR TITLE
When exporting socioeconomic data, enable to filter by a list of country iso codes

### DIFF
--- a/openquakeplatform/openquakeplatform/svir/urls.py
+++ b/openquakeplatform/openquakeplatform/svir/urls.py
@@ -22,7 +22,9 @@ from django.conf.urls import patterns, include, url
 from openquakeplatform.svir.views import (list_themes,
                                           list_subthemes_by_theme,
                                           export_variables_info,
-                                          export_variables_data_by_ids)
+                                          export_variables_data,
+                                          export_countries_info,
+                                         )
 
 from django.contrib import admin
 admin.autodiscover()
@@ -33,5 +35,9 @@ urlpatterns = patterns(
     url(r'^list_themes', list_themes),
     url(r'^list_subthemes_by_theme', list_subthemes_by_theme),
     url(r'^export_variables_info', export_variables_info),
-    url(r'^export_variables_data_by_ids', export_variables_data_by_ids),
+    # export_variables_data_by_ids has been renamed; the following line
+    # is to avoid breaking clients using the old API
+    url(r'^export_variables_data_by_ids', export_variables_data),
+    url(r'^export_variables_data', export_variables_data),
+    url(r'^export_countries_info', export_countries_info),
 )

--- a/openquakeplatform/openquakeplatform/svir/views.py
+++ b/openquakeplatform/openquakeplatform/svir/views.py
@@ -141,8 +141,8 @@ def export_variables_info(request):
     # We don't need 'Tag' anymore, but we need to show other fields
     # We don't display update_periodicity and internal_consistency_metric
     response = HttpResponse(content_type='text/csv')
-    content_disp = 'attachment; filename="socioeconomic_indicators_export.csv"'
-    response['Content-Disposition'] = content_disp
+    response['Content-Disposition'] = \
+        'attachment; filename="socioeconomic_indicators_export.csv"'
     name_str = request.GET.get('name')
     keywords_str = request.GET.get('keywords')
     theme_str = request.GET.get('theme')
@@ -223,8 +223,8 @@ def export_countries_info(request):
     socioeconomic data are available
     """
     response = HttpResponse(content_type='text/csv')
-    content_disp = 'attachment; filename="countries_info_export.csv"'
-    response['Content-Disposition'] = content_disp
+    response['Content-Disposition'] = \
+        'attachment; filename="countries_info_export.csv"'
     copyright = copyright_csv(COPYRIGHT_HEADER)
     writer = csv.writer(response)
     response.write(copyright + "\n")
@@ -270,8 +270,8 @@ def export_variables_data(request):
         country_iso_codes_list = [iso.strip()
                                   for iso in country_iso_codes.split(',')]
     response = HttpResponse(content_type='text/csv')
-    content_disp = 'attachment; filename="sv_data_by_variables_ids_export.csv"'
-    response['Content-Disposition'] = content_disp
+    response['Content-Disposition'] = \
+        'attachment; filename="sv_data_by_variables_ids_export.csv"'
     copyright = copyright_csv(COPYRIGHT_HEADER)
     writer = csv.writer(response)
     response.write(copyright + "\n")

--- a/openquakeplatform/openquakeplatform/svir/views.py
+++ b/openquakeplatform/openquakeplatform/svir/views.py
@@ -109,7 +109,7 @@ def list_subthemes_by_theme(request):
 def export_variables_info(request):
     """
     Export a csv file containing information about the socioeconomic
-    indicators which have the specified keywords and/or subtheme
+    indicators which have the specified name, keywords, theme and/or subtheme
 
     :param request:
         A "GET" :class:`django.http.HttpRequest` object containing at least
@@ -217,16 +217,45 @@ def export_variables_info(request):
 @condition(etag_func=None)
 @allowed_methods(('GET', ))
 @sign_in_required
-def export_variables_data_by_ids(request):
+def export_countries_info(request):
+    """
+    Export a csv file containing iso codes and names of countries for which
+    socioeconomic data are available
+    """
+    response = HttpResponse(content_type='text/csv')
+    content_disp = 'attachment; filename="countries_info_export.csv"'
+    response['Content-Disposition'] = content_disp
+    copyright = copyright_csv(COPYRIGHT_HEADER)
+    writer = csv.writer(response)
+    response.write(copyright + "\n")
+    writer.writerow(['ISO', 'NAME'])
+    inclusive_region = CustomRegion.objects.get(
+        name='Countries with socioeconomic data')
+    for country in inclusive_region.countries.all():
+        # NOTE: It depends on which country model is being used
+        # row = [country.iso, country.name_engli.encode('utf-8')]
+        row = [country.iso, country.name_0.encode('utf-8')]
+        writer.writerow(row)
+    return response
+
+
+@condition(etag_func=None)
+@allowed_methods(('GET', ))
+@sign_in_required
+def export_variables_data(request):
     """
     Export a csv file containing data corresponding to the social vulnerability
     variables which ids are given in input
+    If country iso codes are also provided, only the corresponding data will
+    be exported
 
     :param request:
         A "GET" :class:`django.http.HttpRequest` object containing the
         following parameter:
             * 'sv_variables_ids': a string of comma-separated ids of social
                                   vulnerability variables
+            * 'country_iso_codes': a string of comma-separated country iso
+                                   codes
             * 'export_geometries': a boolean indicating if the geometries of
                                    countries need to be exported too
     """
@@ -235,6 +264,11 @@ def export_variables_data_by_ids(request):
                ' must be specified')
         response = HttpResponse(msg, status="400")
         return response
+    country_iso_codes = request.GET.get('country_iso_codes')
+    country_iso_codes_list = []
+    if country_iso_codes:
+        country_iso_codes_list = [iso.strip()
+                                  for iso in country_iso_codes.split(',')]
     response = HttpResponse(content_type='text/csv')
     content_disp = 'attachment; filename="sv_data_by_variables_ids_export.csv"'
     response['Content-Disposition'] = content_disp
@@ -256,6 +290,8 @@ def export_variables_data_by_ids(request):
     inclusive_region = CustomRegion.objects.get(
         name='Countries with socioeconomic data')
     for country in inclusive_region.countries.all():
+        if country_iso_codes and country.iso not in country_iso_codes_list:
+            continue
         # NOTE: It depends on which country model is being used
         # row = [country.iso, country.name_engli.encode('utf-8')]
         row = [country.iso, country.name_0.encode('utf-8')]


### PR DESCRIPTION
This addresses https://bugs.launchpad.net/oq-platform/+bug/1411611 and is related to https://bugs.launchpad.net/oq-svir/+bug/1411613
* Add API method to list countries and iso codes (useful to populate in QGIS a list of countries for which socioeconomic data are available)
* when exporting socioeconomic data, accept an additional optional parameter to refine the filtering by iso codes (I renamed a API method, but the old name is still available for compatibility with the old client versions, and the old workflow still works)