### PR TITLE
Add TaxTweb to AUTH_EXEMPT_URLS

### DIFF
--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -362,7 +362,8 @@ AUTH_EXEMPT_URLS = ('/$',
                     '/vulnerability/intensity_measure_csc?.*',
                     '/vulnerability/engineering_demand_csc?.*',
                     '/vulnerability/resp_var_par_csc?.*',
-                    '/vulnerability/resp_var_units_csc?.*')
+                    '/vulnerability/resp_var_units_csc?.*',
+                    '/taxtweb/')
 
 # Uncomment to allow open registration.
 # FIXME: there's no admin validation on new accounts.


### PR DESCRIPTION
This allows the reverse proxy to load TaxTweb as a standalone application