### PR TITLE
Icebox layer deletion

### DIFF
--- a/openquakeplatform/openquakeplatform/icebox/models.py
+++ b/openquakeplatform/openquakeplatform/icebox/models.py
@@ -157,14 +157,15 @@ class Calculation(models.Model):
     def remove_calc(sender, instance, using, **_kwargs):
         if instance.map_id:
             for layer in instance.map.layer_set.all():
-                layer_obj = Layer.objects.get(typename=layer.name)
-                if layer_obj.store == 'icebox':
-                    cursor = connection.cursor()
-                    # layer name format is 'oqplatform:view_name'
-                    view_name = layer.name.split(":")[1]
-                    cursor.execute("DROP VIEW IF EXISTS %s" % view_name)
-                    cursor.connection.commit()
-                    layer_obj.delete()
+                if layer.name.startswith('oqplatform:icebox_output'):
+                    layer_obj = Layer.objects.get(typename=layer.name)
+                    if layer_obj.store == 'icebox':
+                        cursor = connection.cursor()
+                        # layer name format is 'oqplatform:view_name'
+                        view_name = layer.name.split(":")[1]
+                        cursor.execute("DROP VIEW IF EXISTS %s" % view_name)
+                        cursor.connection.commit()
+                        layer_obj.delete()
             instance.map.delete()
 
     def __unicode__(self):

--- a/openquakeplatform/openquakeplatform/icebox/models.py
+++ b/openquakeplatform/openquakeplatform/icebox/models.py
@@ -156,6 +156,9 @@ class Calculation(models.Model):
     @staticmethod
     def remove_map(sender, instance, using, **_kwargs):
         if instance.map_id:
+            for layer in instance.map.layer_set.all():
+                import pdb; pdb.set_trace()
+                layer.delete()
             instance.map.delete()
 
     def __unicode__(self):
@@ -379,14 +382,14 @@ class Output(models.Model):
         raise NotImplementedError
 
     @staticmethod
-    def remove_layer(_sender, instance, _using, **_kwargs):
+    def remove_layer(sender, instance, using, **_kwargs):
         """
         Remove the geonode layer as well
         """
         instance.layer.delete()
 
     @staticmethod
-    def drop_view(_sender, instance, _using, **_kwargs):
+    def drop_view(sender, instance, using, **_kwargs):
         cursor = connection.cursor()
         view_name = "icebox_output_%s_%s" % (
             instance.__class__.__name__, instance.output_layer_id)
@@ -402,8 +405,8 @@ class Output(models.Model):
 
 
 models.signals.post_delete.connect(Calculation.remove_map, sender=Calculation)
-models.signals.post_delete.connect(Output.remove_layer, sender=Output)
-models.signals.post_delete.connect(Output.drop_view, sender=Output)
+#models.signals.post_delete.connect(Output.remove_layer, sender=Calculation)
+#models.signals.post_delete.connect(Output.drop_view, sender=Calculation)
 
 
 class HazardMap(Output):

--- a/openquakeplatform/openquakeplatform/icebox/models.py
+++ b/openquakeplatform/openquakeplatform/icebox/models.py
@@ -134,6 +134,7 @@ class Calculation(models.Model):
                     format="image/png",
                     visibility=(i == 0),
                     transparent=True,
+                    group="icebox",
                     ows_url=ogc_server_settings.public_url + "wms",
                     layer_params=json.dumps({"infoFormat": info_format}),
                     local=True))

--- a/openquakeplatform/openquakeplatform/icebox/models.py
+++ b/openquakeplatform/openquakeplatform/icebox/models.py
@@ -272,21 +272,9 @@ class OutputLayer(models.Model):
 
         :returns: the name of the published layer
         """
-        # During development, it might be handy to uncomment this
-        # self.delete_layer(view_name)
         self.update_layer(self.create_featuretype(view_name))
 
         return view_name
-
-    # FIXME: this function is not called. Geoserver layers survive
-    # when a calculation is deleted!
-    def delete_layer(self, view_name):
-        geoserver.geoserver_rest(
-            geoserver.LAYER_URL % view_name, method='DELETE',
-            raise_errors=False)
-        geoserver.geoserver_rest(
-            (geoserver.FEATURETYPE_URL % dict(ws=geoserver.WS_NAME, ds=DS_NAME)) % view_name, method='DELETE',
-            raise_errors=False)
 
     @staticmethod
     def _xml(request_type):

--- a/openquakeplatform/openquakeplatform/icebox/models.py
+++ b/openquakeplatform/openquakeplatform/icebox/models.py
@@ -299,7 +299,7 @@ class OutputLayer(models.Model):
             os.path.join(
                 os.path.dirname(
                     os.path.dirname(__file__)),
-            "build-gs-tree/tmpl/icebox/%s.xml.tmpl" % request_type))
+                "build-gs-tree/tmpl/icebox/%s.xml.tmpl" % request_type))
 
     def create_featuretype(self, view_name):
         """

--- a/openquakeplatform/openquakeplatform/icebox/models.py
+++ b/openquakeplatform/openquakeplatform/icebox/models.py
@@ -387,14 +387,6 @@ class Output(models.Model):
 
         raise NotImplementedError
 
-    @staticmethod
-    def remove_layer(sender, instance, using, **_kwargs):
-        """
-        Remove the geonode layer as well
-        """
-        instance.layer.delete()
-
-    @staticmethod
     def drop_view(sender, instance, using, **_kwargs):
         cursor = connection.cursor()
         view_name = "icebox_output_%s_%s" % (

--- a/openquakeplatform/openquakeplatform/icebox/models.py
+++ b/openquakeplatform/openquakeplatform/icebox/models.py
@@ -134,7 +134,6 @@ class Calculation(models.Model):
                     format="image/png",
                     visibility=(i == 0),
                     transparent=True,
-                    group="icebox",
                     ows_url=ogc_server_settings.public_url + "wms",
                     layer_params=json.dumps({"infoFormat": info_format}),
                     local=True))
@@ -158,9 +157,10 @@ class Calculation(models.Model):
     def remove_calc(sender, instance, using, **_kwargs):
         if instance.map_id:
             for layer in instance.map.layer_set.all():
-                if layer.group == 'icebox':
-                    layer_obj = Layer.objects.get(typename=layer.name)
+                layer_obj = Layer.objects.get(typename=layer.name)
+                if layer_obj.store == 'icebox':
                     cursor = connection.cursor()
+                    # layer name format is 'oqplatform:view_name'
                     view_name = layer.name.split(":")[1]
                     cursor.execute("DROP VIEW IF EXISTS %s" % view_name)
                     cursor.connection.commit()

--- a/openquakeplatform/openquakeplatform/icebox/models.py
+++ b/openquakeplatform/openquakeplatform/icebox/models.py
@@ -387,14 +387,6 @@ class Output(models.Model):
 
         raise NotImplementedError
 
-    def drop_view(sender, instance, using, **_kwargs):
-        cursor = connection.cursor()
-        view_name = "icebox_output_%s_%s" % (
-            instance.__class__.__name__, instance.output_layer_id)
-        view_name = view_name.lower()
-        cursor.execute("DROP VIEW IF EXISTS %s view_name")
-        cursor.connection.commit()
-
     @classmethod
     def bbox_for_output(cls, output_layer):
         return dict(


### PR DESCRIPTION
This PR will trigger layer and maps removal when an Icebox calculation is deleted. It will also DROP the database view associated with the icebox output.

We are missing a migration to add layers previously produced by Icebox in the "icebox" layers group. This will be part of a separate PR.

Thanks @ptormene for the peering.