### PR TITLE
Move git_suffix out of utils.py since utils requires Django.

### DIFF
--- a/openquakeplatform/openquakeplatform/__init__.py
+++ b/openquakeplatform/openquakeplatform/__init__.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import utils
+import version
 
 __version__ = '1.0.1'
-__version__ += utils.git_suffix(__file__)
+__version__ += version.git_suffix(__file__)

--- a/openquakeplatform/openquakeplatform/utils.py
+++ b/openquakeplatform/openquakeplatform/utils.py
@@ -22,23 +22,6 @@ class allowed_methods(object):
         return wrapped
 
 
-def git_suffix(fname):
-    """
-    :returns: `<short git hash>` if Git repository found
-    """
-    try:
-        gh = subprocess.check_output(
-            ['git', 'rev-parse', '--short', 'HEAD'],
-            stderr=open(os.devnull, 'w'),
-            cwd=os.path.dirname(fname)).strip()
-        gh = "-git" + gh if gh else ''
-        return gh
-    except:
-        # trapping everything on purpose; git may not be installed or it
-        # may not work properly
-        return ''
-
-
 def oq_context_processor(request):
     """
     A custom context processor which allows injection of additional

--- a/openquakeplatform/openquakeplatform/version.py
+++ b/openquakeplatform/openquakeplatform/version.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+
+
+def git_suffix(fname):
+    """
+    :returns: `<short git hash>` if Git repository found
+    """
+    try:
+        gh = subprocess.check_output(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            stderr=open(os.devnull, 'w'),
+            cwd=os.path.dirname(fname)).strip()
+        gh = "-git" + gh if gh else ''
+        return gh
+    except:
+        # trapping everything on purpose; git may not be installed or it
+        # may not work properly
+        return ''


### PR DESCRIPTION
When the code is installed in a clean environment, without Django,
utils.py cannot be imported but is required to get code version.