### PR TITLE
Fix migrations copy in deploy.sh

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -656,7 +656,7 @@ oq_platform_install () {
     if [ ! -d "$MIGRATIONS_HISTORY" ]; then
         mkdir -p "$MIGRATIONS_HISTORY"
     fi
-    cp oq-platform/openquakeplatform/migrations/*.{py,sh,sql} "${MIGRATIONS_HISTORY}/"
+    find oq-platform/openquakeplatform/migrations -type f \( -name "*.py" -or -name "*.sql" -or -name "*.sh" \) -exec cp "{}" "${MIGRATIONS_HISTORY}/" \;
 
 }
 


### PR DESCRIPTION
Fix migrations copy in deploy.sh where some file extensions are not present in the src folder.

`cp` fails if any of `*.sh`, `*.sql` or `*.py` is not present in the migrations dir. This will bring `deploy.sh` to a failure.