### PR TITLE
Layers selector

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/hazus.js
+++ b/openquakeplatform/openquakeplatform/static/js/hazus.js
@@ -23,6 +23,17 @@ var TILESTREAM_URL = TS_URL + '/v2/';
 
 var startApp = function() {
 
+    // Show hide layer controller
+    function checkLayerController() {
+        if ($.isEmptyObject(layerControl._layers) ) {
+            setTimeout(function() {
+                $('.leaflet-control-layers-toggle').css({'display': 'none'});
+            }, 100);
+        } else {
+            $('.leaflet-control-layers-toggle').css({'display': 'block'});
+        }
+    }
+
     $(function() {
         $( "#dialog" ).dialog({height: 520, width: 430, position: {at: "right bottom"}});
         $('#dialog').dialog('close');
@@ -36,6 +47,7 @@ var startApp = function() {
     map.setView(new L.LatLng(10, -10), 2).addLayer(baseMapUrl);
 
     layerControl = L.control.layers(app.baseLayers);
+    checkLayerController();
 
     map.addControl(layerControl.setPosition("topleft"));
     map.panTo(new L.LatLng(38.2, -101.6));
@@ -64,6 +76,7 @@ var startApp = function() {
 
         layerControl.addOverlay(utfGridGroup, selectedLayer);
         map.addLayer(utfGridGroup);
+        checkLayerController();
         utfGridClickEvent(layerType);
 
         return utfGrid;
@@ -82,6 +95,7 @@ var startApp = function() {
             var building_fractions = L.tileLayer(TS_URL + '/v2/ged_hazus_US_building_fractions_black/{z}/{x}/{y}.png');
             layerControl.addOverlay(building_fractions, "US Counties");
             map.addLayer(building_fractions);
+            checkLayerController();
         } else if (externalLayerSelection == 3) {
             var selectedLayer = "dwelling_fractions_non_res";
             var selectedGrid = "n/a";

--- a/openquakeplatform/openquakeplatform/static/js/hrde.js
+++ b/openquakeplatform/openquakeplatform/static/js/hrde.js
@@ -80,6 +80,18 @@ var TILESTREAM_API_URL = TS_URL + '/api/v1/Tileset/';
 var app = new OQLeaflet.OQLeafletApp(baseMapUrl);
 
 var startApp = function() {
+
+    // Show hide layer controller
+    function checkLayerController() {
+        if ($.isEmptyObject(AppVars.layerControl._layers) ) {
+            setTimeout(function() {
+                $('.leaflet-control-layers-toggle').css({'display': 'none'});
+            }, 100);
+        } else {
+            $('.leaflet-control-layers-toggle').css({'display': 'block'});
+        }
+    }
+
     $(function() {
         $('#chartDialog').dialog({
             autoOpen: false,
@@ -174,6 +186,7 @@ var startApp = function() {
     layers = {};
 
     AppVars.layerControl = L.control.layers(app.baseLayers);
+    checkLayerController();
     map.scrollWheelZoom.enable();
     map.options.maxBounds = null;
 
@@ -184,6 +197,7 @@ var startApp = function() {
         if (externalLayerSelection == 1) {
             var strain = new L.TileLayer(TILESTREAM_URL+'geodetic-strain-v2-1/{z}/{x}/{y}.png');
             map.addLayer(strain);
+            checkLayerController();
             AppVars.layerControl.addOverlay(strain, "Strain");
         } else if (externalLayerSelection == 3) {
             var iec = L.tileLayer.wms("/geoserver/wms", {
@@ -193,6 +207,7 @@ var startApp = function() {
                 version: '1.1.0'
             });
             map.addLayer(iec);
+            checkLayerController();
             AppVars.layerControl.addOverlay(iec, "Instrumental Earthquake Catalogue");
         } else if (externalLayerSelection == 4) {
             var hec = L.tileLayer.wms("/geoserver/wms", {
@@ -202,6 +217,7 @@ var startApp = function() {
                 version: '1.1.0'
             });
             map.addLayer(hec);
+            checkLayerController();
             AppVars.layerControl.addOverlay(hec, "Historic Earthquake Catalogue");
         }
     });
@@ -1018,6 +1034,7 @@ var startApp = function() {
 
         AppVars.layerControl.addOverlay(utfGridGroup, selectedLayer);
         map.addLayer(utfGridGroup);
+        checkLayerController();
         if (curveType == undefined || curveType == 'map') {
             Opacity(tileLayer);
         }
@@ -1116,6 +1133,7 @@ var startApp = function() {
 
         AppVars.layerControl.addOverlay(utfGrid, selectedLayer);
         map.addLayer(utfGrid);
+        checkLayerController();
         lossCurveUtfGridClickEvent(utfGridLoss);
     }
 
@@ -1180,6 +1198,7 @@ var startApp = function() {
 
         AppVars.layerControl.addOverlay(utfGridMixed, selectedLayer);
         map.addLayer(utfGridMixed);
+        checkLayerController();
         hazardCurveUtfGridClickEventMixed(utfGrid, curveType);
     }
 


### PR DESCRIPTION
This PR provides logic to hide the leaflet layer controller when no layers are loaded, and then show the controller when layers are present. The feature is only required in the Hazus and HRDE applications as all other leaflet based applications are preloaded with layers.