### PR TITLE
Improve traceback display. Use bootstrap modal instead of popups

### DIFF
--- a/openquakeplatform/openquakeplatform/icebox/static/icebox/calculate.js
+++ b/openquakeplatform/openquakeplatform/icebox/static/icebox/calculate.js
@@ -148,6 +148,11 @@
      });
    var outputs = new Outputs();
 
+   var refresh_calcs;
+
+   function setTimer() {
+       refresh_calcs = setInterval(function() { calculations.fetch({reset: true}) }, 5000);
+   }
 
    /* classic event management */   
 
@@ -155,7 +160,7 @@
      function() {
        var calculation_table = new CalculationTable({ calculations: calculations });
        calculations.fetch({reset: true});
-       setInterval(function() { calculations.fetch({reset: true}) }, 5000);
+       setTimer();
 
        var output_table = new OutputTable({ outputs: outputs });
        outputs.fetch({reset: true});
@@ -190,6 +195,14 @@
                               dialog.hidePleaseWait();
                               alert(xhr.responseText);
 		                        }});
+                      });
+      $(document).on('click', 'button[id=open_trace]',
+                function(e) {
+                        clearInterval(refresh_calcs);
+                      });
+      $(document).on('click', 'button[id=close_trace]',
+                function(e) {
+                        setTimer();
                       });
      });
  })($, Backbone, _);

--- a/openquakeplatform/openquakeplatform/icebox/static/icebox/calculate.js
+++ b/openquakeplatform/openquakeplatform/icebox/static/icebox/calculate.js
@@ -200,9 +200,10 @@
                 function(e) {
                         clearInterval(refresh_calcs);
                       });
-      $(document).on('click', 'button[id=close_trace]',
-                function(e) {
+      $(document).on('hidden.bs.modal', 'div[id^=traceback]',
+                function (e) {
                         setTimer();
+
                       });
      });
  })($, Backbone, _);

--- a/openquakeplatform/openquakeplatform/icebox/static/icebox/calculate.js
+++ b/openquakeplatform/openquakeplatform/icebox/static/icebox/calculate.js
@@ -201,7 +201,7 @@
                         clearInterval(refresh_calcs);
                       });
       $(document).on('hidden.bs.modal', 'div[id^=traceback]',
-                function (e) {
+                function(e) {
                         setTimer();
 
                       });

--- a/openquakeplatform/openquakeplatform/icebox/static/icebox/calculate.js
+++ b/openquakeplatform/openquakeplatform/icebox/static/icebox/calculate.js
@@ -200,10 +200,9 @@
                 function(e) {
                         clearInterval(refresh_calcs);
                       });
-      $(document).on('hidden.bs.modal', 'div[id^=traceback]',
+      $(document).on('hidden.bs.modal', 'div[id^=traceback-]',
                 function(e) {
                         setTimer();
-
                       });
      });
  })($, Backbone, _);

--- a/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
+++ b/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
@@ -101,8 +101,8 @@ Calculate - {{block.super}}
 
           <% if(calc.get('id')) { %>
             <% if(calc.get('status') == 'failed') { %>
-              <button id="open_trace" class="btn btn-sm" type="button" data-toggle="modal" data-target="#traceback<%= calc.get('id') %>">Traceback</button>
-              <div class="modal fade" id="traceback<%= calc.get('id') %>">
+              <button id="open_trace" class="btn btn-sm" type="button" data-toggle="modal" data-target="#traceback-<%= calc.get('id') %>">Traceback</button>
+              <div class="modal fade" id="traceback-<%= calc.get('id') %>">
                 <div class="modal-dialog">
                   <div class="modal-content">
                     <div class="modal-header">

--- a/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
+++ b/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
@@ -113,7 +113,7 @@ Calculate - {{block.super}}
                       <pre><%= calc.get('einfo') %></pre>
                     </div>
                     <div class="modal-footer">
-                      <button id="close_trace" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                      <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                   </div>
                 </div>

--- a/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
+++ b/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
@@ -7,7 +7,7 @@ Calculate - {{block.super}}
 {% block extra_head %}
 {{block.super}}
 
-    <link href="{{ STATIC_URL }}/bootstrap-extend/css/jasny-bootstrap.min.css" rel="stylesheet"/>
+    <link href="{{ STATIC_URL }}bootstrap-extend/css/jasny-bootstrap.min.css" rel="stylesheet"/>
 
 {% endblock %}
 
@@ -127,14 +127,6 @@ Calculate - {{block.super}}
       <% }); %>
     </tbody>
   </table>
-</script>
-
-<script>
-  function popup_error_traceback(traceback) {
-    var w = window.open('', 'Traceback', 'width=1000, height=600, resizable, scrollbars');
-    w.document.write('<pre>' + traceback + '</pre>')
-    w.document.close();
-  }
 </script>
 
 <script type="text/template" id="output-table-template">

--- a/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
+++ b/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
@@ -102,7 +102,7 @@ Calculate - {{block.super}}
           <% if(calc.get('id')) { %>
             <% if(calc.get('status') == 'failed') { %>
               <button id="open_trace" class="btn btn-sm" type="button" data-toggle="modal" data-target="#traceback-<%= calc.get('id') %>">Traceback</button>
-              <div class="modal fade" id="traceback-<%= calc.get('id') %>">
+              <div class="modal fade" id="traceback-<%= calc.get('id') %>" style="display: none;">
                 <div class="modal-dialog">
                   <div class="modal-content">
                     <div class="modal-header">

--- a/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
+++ b/openquakeplatform/openquakeplatform/icebox/templates/icebox.html
@@ -101,8 +101,23 @@ Calculate - {{block.super}}
 
           <% if(calc.get('id')) { %>
             <% if(calc.get('status') == 'failed') { %>
-              <% traceback = calc.get('einfo') %>
-              <button class="btn btn-sm" onclick="popup_error_traceback(traceback)">Traceback</button>
+              <button id="open_trace" class="btn btn-sm" type="button" data-toggle="modal" data-target="#traceback<%= calc.get('id') %>">Traceback</button>
+              <div class="modal fade" id="traceback<%= calc.get('id') %>">
+                <div class="modal-dialog">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                      <h4 class="modal-title">Traceback from calculation #<%= calc.get('id') %></h4>
+                    </div>
+                    <div class="modal-body">
+                      <pre><%= calc.get('einfo') %></pre>
+                    </div>
+                    <div class="modal-footer">
+                      <button id="close_trace" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
             <% } %>
             <a href="#" data-calc-id="<%= calc.get('id') %>" class="btn btn-sm btn-danger">Remove</a>
          <% } %>


### PR DESCRIPTION
This solves the issue where the same traceback is reported to all the failing jobs, causing confusion on the causes of a failure.
This also replace pop-ups with a modal dialog. Pop-ups are evil: sometime they are blocked, they go back the main windows... and so; since our pop-ups are "self called" (they are not pointing to an external url) are also difficult to style and manage. Now syntax highlighting can be easily added.

![screenshot from 2015-03-20 18 14 25](https://cloud.githubusercontent.com/assets/1818657/6756864/146ba700-cf2d-11e4-96a5-e901cc6089fa.png)

Fixes: https://bugs.launchpad.net/oq-platform/+bug/1434177

More testing is needed before releasing the [WIP].