### PR TITLE
Irv theme chart median line

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -18,6 +18,9 @@ var layerAttributes;
 var sessionProjectDef = [];
 var selectedRegion;
 var selectedIndicator;
+var selectedLayer;
+var boundingBox;
+var tempProjectDef;
 
 // sessionProjectDef is the project definition as is was when uploaded from the QGIS tool.
 // While projectDef includes modified weights and is no longer the version that was uploaded from the QGIS tool
@@ -28,6 +31,15 @@ var baseMapUrl = new L.TileLayer('http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x
 var app = new OQLeaflet.OQLeafletApp(baseMapUrl);
 var indicatorChildrenKey = [];
 
+$(function() {
+    $('#saveStateDialog').dialog({
+        autoOpen: false,
+        height: 520,
+        width: 620,
+        closeOnEscape: true,
+        position: {at: 'right bottom'}
+    });
+});
 
 function createIndex(la, index) {
     var indicator = [];
@@ -341,6 +353,7 @@ function processIndicators(layerAttributes, projectDef) {
         generateThemeObject(indicatorObj);
     }
 
+    Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion);
     Theme_PCP_Chart(themeData);
 
     /////////////////////////
@@ -644,9 +657,41 @@ function thematicMap(layerAttributes) {
     legendControl.addTo(map);
 }
 
+function watchForPdSelection() {
+    var pdSelection = $('#pdSelection').val();
+    for (var i = 0; i < tempProjectDef.length; i++) {
+        if (tempProjectDef[i].title === pdSelection) {
+            sessionProjectDef = tempProjectDef[i];
+            loadPD(sessionProjectDef);
+            // get b-box
+            if (boundingBox != undefined) {
+                map.fitBounds (
+                    L.latLngBounds (
+                        L.latLng (
+                            parseFloat(boundingBox.northBoundLatitude.Decimal.__text),
+                            parseFloat(boundingBox.eastBoundLongitude.Decimal.__text)
+                        ),
+                        L.latLng (
+                            parseFloat(boundingBox.southBoundLatitude.Decimal.__text),
+                            parseFloat(boundingBox.westBoundLongitude.Decimal.__text)
+                        )
+                    )
+                );
+            }
+            $('#projectDef-spinner').hide();
+            $('#iri-spinner').hide();
+            $('#project-definition-svg').show();
+            $('#region-selection-list').show();
+        }
+    }
+    processIndicators(layerAttributes, sessionProjectDef);
+}
+
 var startApp = function() {
     $('#projectDef-spinner').hide();
     $('#iri-spinner').hide();
+    $('#primary-spinner').hide();
+    $('#primary_indicator').hide();
     map = new L.Map('map', {
         minZoom: 2,
         scrollWheelZoom: false,
@@ -728,13 +773,16 @@ var startApp = function() {
     $('#svir-project-list').change(function() {
         $('#projectDef-spinner').show();
         $('#iri-spinner').show();
+        $('#primary-spinner').show();
         $('#regionSelectionDialog').empty();
         // FIXME This will not work if the title contains '(' or ')'
         // Get the selected layer
-        var selectedLayer = document.getElementById('svir-project-list').value;
+        selectedLayer = document.getElementById('svir-project-list').value;
         // clean the selected layer to get just the layer name
         selectedLayer = selectedLayer.substring(selectedLayer.indexOf("(") + 1);
         selectedLayer = selectedLayer.replace(/[)]/g, '');
+
+
 
         // Get layer attributes from GeoServer
         $.ajax({
@@ -770,7 +818,7 @@ var startApp = function() {
 
                 $('#region-selection-list').change(function() {
                     selectedRegion = document.getElementById('region-selection-list').value;
-                    getLayerInfo(selectedLayer, layerAttributes);
+                    getLayerInfo(layerAttributes);
                 });
             },
             error: function() {
@@ -783,8 +831,7 @@ var startApp = function() {
         });
     });
 
-
-    function getLayerInfo(selectedLayer, layerAttributes) {
+    function getLayerInfo(layerAttributes) {
         $('#regionSelectionDialog').dialog('close');
         $.ajax({
             type: 'get',
@@ -800,42 +847,16 @@ var startApp = function() {
                 //layerMetadataURL = "/catalogue/csw?outputschema=http%3A%2F%2Fwww.isotc211.org%2F2005%2Fgmd&service=CSW&request=GetRecordById&version=2.0.2&elementsetname=full&id=3dc19270-e41a-11e4-9826-0800278c33b4";
 
                 $.get( layerMetadataURL, function( layerMetadata ) {
-                    //convert XML to JSON
                     var xmlText = new XMLSerializer().serializeToString(layerMetadata);
                     var x2js = new X2JS();
                     var jsonElement = x2js.xml_str2json(xmlText);
-                    //pass a string representing the project def into the d3 tree chart
-                    sessionProjectDefStr = jsonElement.GetRecordByIdResponse.MD_Metadata.identificationInfo.MD_DataIdentification.supplementalInformation.CharacterString.__text;
-                    loadPD(sessionProjectDefStr);
-                    sessionProjectDef = jQuery.parseJSON(sessionProjectDefStr);
-                    // get b-box
-                    var boundingBox = jsonElement.GetRecordByIdResponse.MD_Metadata.identificationInfo.MD_DataIdentification.extent.EX_Extent.geographicElement.EX_GeographicBoundingBox;
-                    if (boundingBox != undefined) {
-                        map.fitBounds (
-                            L.latLngBounds (
-                                L.latLng (
-                                    parseFloat(boundingBox.northBoundLatitude.Decimal.__text),
-                                    parseFloat(boundingBox.eastBoundLongitude.Decimal.__text)
-                                ),
-                                L.latLng (
-                                    parseFloat(boundingBox.southBoundLatitude.Decimal.__text),
-                                    parseFloat(boundingBox.westBoundLongitude.Decimal.__text)
                                 )
-                            )
-                        );
                     }
-                    $('#projectDef-spinner').hide();
-                    $('#iri-spinner').hide();
-                    $('#project-definition-svg').show();
-                    $('#region-selection-list').show();
-                    processIndicators(layerAttributes, sessionProjectDef);
                 });
             },
             error: function() {
             $('#ajaxErrorDialog').empty();
             $('#ajaxErrorDialog').append(
-                    '<p>This application was not able to get the supplemental information about the selected layer</p>'
-                );
             $('#ajaxErrorDialog').dialog('open');
             }
         });

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_theme.js
@@ -30,8 +30,11 @@ function Theme_PCP_Chart(themeData) {
         height = winH - margin.top - margin.bottom;
     var eachValueInThemeData = [];
     var eachElementInThemeData = [];
+    // The combined values for each element in the themeData
     var sum = {};
+    // An object that contains the mean for each region the the themeData
     var sumMean = {};
+    // An array that holds the mean value for each region
     var sumMeanArray = [];
 
     for (var i = 0; i < themeData.length; i++) {
@@ -132,18 +135,18 @@ function Theme_PCP_Chart(themeData) {
     }
 
     //////////////////////
-    //// Meadian line ////
+    //// Median line ////
     //////////////////////
 
     // Build skeleton array
-    for (var t in themeData[0]) {
-        sum[t] = 0;
+    for (var regionKey in themeData[0]) {
+        sum[regionKey] = 0;
     }
 
     // Sum all the paths
-    for (var h = 0; h < themeData.length; h++) {
-        for (var n in themeData[h]) {
-            sum[n] += themeData[h][n];
+    for (var value = 0; value < themeData.length; value++) {
+        for (var regionKey in themeData[value]) {
+            sum[regionKey] += themeData[value][regionKey];
         }
     }
 
@@ -155,7 +158,7 @@ function Theme_PCP_Chart(themeData) {
 
     sumMeanArray.push(sumMean);
 
-    // Plot the meadian line
+    // Plot the median line
     meanPath = svg.append("g")
         .attr("class", "PI-meanPath")
         .selectAll("path")
@@ -164,7 +167,7 @@ function Theme_PCP_Chart(themeData) {
         .attr("d", path)
         .attr('id', function(d) { return d.region; })
             .on('mouseover', function() {
-                textTop.text('Meadian');
+                textTop.text('Median');
             }).on('mouseout', function() {
                 textTop.text('');
             });

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_theme.js
@@ -34,7 +34,7 @@ function Theme_PCP_Chart(themeData) {
     var sum = {};
     // An object that contains the mean for each region the the themeData
     var sumMean = {};
-    // An array that holds the mean value for each region
+    // An array that holds the mean value for each regionKey
     var sumMeanArray = [];
 
     for (var i = 0; i < themeData.length; i++) {
@@ -139,14 +139,16 @@ function Theme_PCP_Chart(themeData) {
     //////////////////////
 
     // Build skeleton array
-    for (var regionKey in themeData[0]) {
-        sum[regionKey] = 0;
+    for (var region in themeData[0]) {
+        sum[region] = 0;
     }
 
     // Sum all the paths
-    for (var value = 0; value < themeData.length; value++) {
-        for (var regionKey in themeData[value]) {
-            sum[regionKey] += themeData[value][regionKey];
+    console.log('themeData:');
+    console.log(themeData);
+    for (var h = 0; h < themeData.length; h++) {
+        for (var themeValue in themeData[h]) {
+            sum[themeValue] += themeData[h][themeValue];
         }
     }
 


### PR DESCRIPTION
Add a median line to the IRV viewer theme chart

This PR is an extension of https://github.com/gem/oq-platform/pull/387

To visualize the median line, open a project in the IRV viewer and then view the 'SVI Theme Chart' tab. Inside of the plot there is a thick/opaque median line. When hovered with the mouse, it's label is rendered above the PCP chart. 