### PR TITLE
Remove the bluemarble baselayer from previously created maps

### DIFF
--- a/openquakeplatform/migrations/002_remove_bluemarble.sql
+++ b/openquakeplatform/migrations/002_remove_bluemarble.sql
@@ -1,3 +1,3 @@
 -- This scripts removes any trace of the bluemarble baselayer from maps
 
-SELECT * FROM maps_maplayer WHERE name = 'bluemarble';
+DELETE FROM maps_maplayer WHERE name = 'bluemarble';

--- a/openquakeplatform/migrations/002_remove_bluemarble.sql
+++ b/openquakeplatform/migrations/002_remove_bluemarble.sql
@@ -1,0 +1,3 @@
+-- This scripts removes any trace of the bluemarble baselayer from maps
+
+SELECT * FROM maps_maplayer WHERE name = 'bluemarble';

--- a/openquakeplatform/openquakeplatform/common/post_fixtures/maps.json
+++ b/openquakeplatform/openquakeplatform/common/post_fixtures/maps.json
@@ -160,26 +160,6 @@
         }
     },
     {
-        "pk": 13,
-        "model": "maps.maplayer",
-        "fields": {
-            "opacity": 1.0,
-            "map": 24,
-            "group": "background",
-            "name": "bluemarble",
-            "format": null,
-            "visibility": false,
-            "source_params": "{\"id\": \"1\", \"ptype\": \"gxp_olsource\"}",
-            "layer_params": "{\"selected\": false, \"title\": \"bluemarble\", \"args\": [\"bluemarble\", \"http://maps.opengeo.org/geowebcache/service/wms\", {\"layers\": [\"bluemarble\"], \"tiled\": true, \"tilesOrigin\": [-20037508.34, -20037508.34], \"format\": \"image/png\"}, {\"buffer\": 0}], \"type\": \"OpenLayers.Layer.WMS\"}",
-            "ows_url": null,
-            "stack_order": 5,
-            "styles": null,
-            "fixed": true,
-            "local": false,
-            "transparent": false
-        }
-    },
-    {
         "pk": 14,
         "model": "maps.maplayer",
         "fields": {
@@ -300,26 +280,6 @@
         }
     },
     {
-        "pk": 28,
-        "model": "maps.maplayer",
-        "fields": {
-            "opacity": 1.0,
-            "map": 23,
-            "group": "background",
-            "name": "bluemarble",
-            "format": null,
-            "visibility": false,
-            "source_params": "{\"ptype\": \"gxp_olsource\", \"id\": \"0\"}",
-            "layer_params": "{\"selected\": false, \"title\": \"bluemarble\", \"args\": [\"bluemarble\", \"http://maps.opengeo.org/geowebcache/service/wms\", {\"layers\": [\"bluemarble\"], \"tiled\": true, \"tilesOrigin\": [-20037508.34, -20037508.34], \"format\": \"image/png\"}, {\"buffer\": 0}], \"type\": \"OpenLayers.Layer.WMS\"}",
-            "ows_url": null,
-            "stack_order": 5,
-            "styles": null,
-            "fixed": true,
-            "local": false,
-            "transparent": false
-        }
-    },
-    {
         "pk": 29,
         "model": "maps.maplayer",
         "fields": {
@@ -433,26 +393,6 @@
             "layer_params": "{\"title\": \"Bing Aerial With Labels\", \"selected\": false}",
             "ows_url": null,
             "stack_order": 4,
-            "styles": null,
-            "fixed": true,
-            "local": false,
-            "transparent": false
-        }
-    },
-    {
-        "pk": 35,
-        "model": "maps.maplayer",
-        "fields": {
-            "opacity": 1.0,
-            "map": 25,
-            "group": "background",
-            "name": "bluemarble",
-            "format": null,
-            "visibility": false,
-            "source_params": "{\"ptype\": \"gxp_olsource\", \"id\": \"0\"}",
-            "layer_params": "{\"selected\": true, \"title\": \"bluemarble\", \"args\": [\"bluemarble\", \"http://maps.opengeo.org/geowebcache/service/wms\", {\"layers\": [\"bluemarble\"], \"tiled\": true, \"tilesOrigin\": [-20037508.34, -20037508.34], \"format\": \"image/png\"}, {\"buffer\": 0}], \"type\": \"OpenLayers.Layer.WMS\"}",
-            "ows_url": null,
-            "stack_order": 5,
             "styles": null,
             "fixed": true,
             "local": false,
@@ -593,26 +533,6 @@
             "layer_params": "{\"title\": \"Bing Aerial With Labels\", \"selected\": false}",
             "ows_url": null,
             "stack_order": 4,
-            "styles": null,
-            "fixed": true,
-            "local": false,
-            "transparent": false
-        }
-    },
-    {
-        "pk": 43,
-        "model": "maps.maplayer",
-        "fields": {
-            "opacity": 1.0,
-            "map": 26,
-            "group": "background",
-            "name": "bluemarble",
-            "format": null,
-            "visibility": false,
-            "source_params": "{\"id\": \"1\", \"ptype\": \"gxp_olsource\"}",
-            "layer_params": "{\"selected\": false, \"title\": \"bluemarble\", \"args\": [\"bluemarble\", \"http://maps.opengeo.org/geowebcache/service/wms\", {\"layers\": [\"bluemarble\"], \"tiled\": true, \"tilesOrigin\": [-20037508.34, -20037508.34], \"format\": \"image/png\"}, {\"buffer\": 0}], \"type\": \"OpenLayers.Layer.WMS\"}",
-            "ows_url": null,
-            "stack_order": 5,
             "styles": null,
             "fixed": true,
             "local": false,


### PR DESCRIPTION
Bluemarble has been already deprecated as baselayer for new maps, but it's still present in fixtures and pre-generated maps (and their child).

This PR updates pre-generated maps fixures and add an SQL migration to remove the layers from any maps already stored.