### PR TITLE
Irv small ux improvements

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -907,6 +907,14 @@ var startApp = function() {
                     );
                 }
                 $('#projectDef-spinner').hide();
+
+                // select the first indicator
+                var menuOption = $('#pdSelection');
+                menuOption[0].selectedIndex = 1;
+                // trigger first indicator
+                setTimeout(function() {
+                    $('#pdSelection').trigger('change');
+                }, 100);
             },
             error: function() {
                 $('#ajaxErrorDialog').empty();

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -912,10 +912,10 @@ var startApp = function() {
                 }
                 $('#projectDef-spinner').hide();
 
-                // select the first indicator
+                // select the first project definition
                 var menuOption = $('#pdSelection');
                 menuOption[0].selectedIndex = 1;
-                // trigger first indicator
+                // trigger first project definition
                 setTimeout(function() {
                     $('#pdSelection').trigger('change');
                 }, 100);

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_primary.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_primary.js
@@ -48,6 +48,14 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
     }
     $('#primary_indicator').show();
 
+    // select the first indicator
+    var menuOption = $('#primary_indicator');
+    menuOption[0].selectedIndex = 1;
+    // trigger first indicator
+    setTimeout(function() {
+        $('#primary_indicator').trigger('change');
+    }, 100);
+
     $('#primary_indicator').change(function() {
         var selectedTheme = $('#primary_indicator').val();
         // Find the children of selected theme

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_theme.js
@@ -38,7 +38,9 @@ function Theme_PCP_Chart(themeData) {
 
     for (var i = 0; i < themeData.length; i++) {
         for (var k in themeData[i]){
-            eachElementInThemeData.push(themeData[i][k]);
+            if (k != 'region') {
+                eachElementInThemeData.push(themeData[i][k]);
+            }
         }
     }
 
@@ -48,6 +50,9 @@ function Theme_PCP_Chart(themeData) {
             eachValueInThemeData.push(eachElementInThemeData[i]);
         }
     }
+
+    console.log('eachValueInThemeData:');
+    console.log(eachValueInThemeData);
 
     var maxVal = Math.max.apply( Math, eachValueInThemeData );
     var minVal = Math.min.apply( Math, eachValueInThemeData );

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_theme.js
@@ -24,6 +24,26 @@
 
 function Theme_PCP_Chart(themeData) {
 
+    // Disable the theme tab if there is only on theme and the region attributes in themeData.
+    function countProperties(themeData) {
+        var themeCount = 0;
+
+        for(var prop in themeData) {
+            if(themeData.hasOwnProperty(prop))
+                ++themeCount;
+        }
+        return themeCount;
+    }
+
+    var themeCount = countProperties(themeData[0]);
+
+    if (themeCount <= 2) {
+        // Disable the theme tab.
+        $("#themeTabs").tabs("disable", 2);
+        // Stop the function from continuing.
+        return;
+    }
+
     var data = themeData;
     var winH = ($(window).height() / 1.5);
     var winW = ($(window).width());
@@ -44,15 +64,11 @@ function Theme_PCP_Chart(themeData) {
         }
     }
 
-
     for (var i = 0; i < eachElementInThemeData.length; i++) {
         if (!isNaN(parseFloat(eachElementInThemeData[i])) && isFinite(eachElementInThemeData[i])) {
             eachValueInThemeData.push(eachElementInThemeData[i]);
         }
     }
-
-    console.log('eachValueInThemeData:');
-    console.log(eachValueInThemeData);
 
     var maxVal = Math.max.apply( Math, eachValueInThemeData );
     var minVal = Math.min.apply( Math, eachValueInThemeData );

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -15,6 +15,7 @@
       along with this program.  If not, see <https://www.gnu.org/licenses/agpl.html>.
 */
 
+    var DEFAULT_OPERATOR = "Weighted sum"
     var CIRCLE_SCALE = 30;
     var MAX_STROKE_SIZE = 4;
     var MIN_CIRCLE_SIZE = 0.001;

--- a/openquakeplatform/openquakeplatform/templates/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/templates/irv_viewer.html
@@ -55,6 +55,7 @@ IRV - {{block.super}}
     ng-controller="HazardMapDropdown"
     title="Load Project"
     style="overflow: hidden;">
+      <div id="load-project-spinner" >Loading ...<img src="{{ STATIC_URL }}img/ajax-loader.gif" /></div>
 
       Filter the project list:<br><input type="text" ng-model="search">
       <br><br>


### PR DESCRIPTION
This PR includes several small UX improvements. 

1. Automatically select and trigger the selection of the first project definition in the selection dropdown menu. To test, open the IRV application, and select a project. The loading spinner will indicate that the APIs are working, after a few moments, the loading spinner will be hidden and now you can see that the first project definition has been automatically selected in the dropdown menu and triggered. In addition, this d3.js project definition tree is now rendered.

2. Automatically select and trigger the selection of the first primary indicator. Similar to #1, once a project has been selected, the first primary indicator from inside the 'primary indicator chart' tab is automatically selected and triggered.

3. Disable the theme tab if there is only one theme in themeData. This can be tested by loading a project that has only one SVI theme child. You will now see that once the project is loaded, the 'SVI theme chart' tab will be disabled.

4. If the selected zone includes numbers instead of chericters, then these values were being used to identify the max value used for the SVI theme chart. To correct this I am now discriminating againset the 'region' elements.

5. Provide a default operator for the pd tree (for corner cases)

6. Call the project list API each time the load project dialog is opened. This will allow the user to access newly created project without reloading the page.