### PR TITLE
[WIP] Remind for IRV documentation review

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -462,6 +462,7 @@ function processIndicators(layerAttributes, projectDef) {
                 la[ix].newProperties['IRI'] = (IRI[key]).toFixed(5);
             }
         }
+
         for (var key in SVI) {
             if (key == la[ix].properties[selectedRegion]) {
                 la[ix].newProperties['SVI'] = (SVI[key]).toFixed(5);


### PR DESCRIPTION
the only reason for this change is to create a ‘empty’ pull request. The real pull request is for the modifications to the user documentation for the irv application that can be found here: http://www.globalquakemodel.org/openquake/support/documentation/platform/irv/

The new version includes new screen casts, and covers the process of accessing saved PD's and saving new PDs.