### PR TITLE
Taxt short2

### DIFF
--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -2591,6 +2591,10 @@ function taxt_BuildTaxonomy()
             $('#noStoreysE12').addClass('gem_field_alert');
             h12 = false;
         }
+        else if (parseInt($('#noStoreysE11').val()) == parseInt($('#noStoreysE12').val())) {
+            ret_s.s = "Number of storey above ground: invalid range.";
+            return (false);
+        }
         else {
             $('#noStoreysE12').removeClass('gem_field_alert');
         }
@@ -2627,6 +2631,10 @@ function taxt_BuildTaxonomy()
             $('#noStoreysE22').addClass('gem_field_alert');
             h22 = false;
         }
+        else if (parseInt($('#noStoreysE21').val()) == parseInt($('#noStoreysE22').val())) {
+            ret_s.s = "Number of storey above ground: invalid range.";
+            return (false);
+        }
         else {
             $('#noStoreysE22').removeClass('gem_field_alert');
         }
@@ -2659,6 +2667,10 @@ function taxt_BuildTaxonomy()
         if (!is_not_negative_float($('#noStoreysE32').val())) {
             validate_msg += "Height of ground floor level: upper limit not positive real. ";
             $('#noStoreysE32').addClass('gem_field_alert');
+        }
+        else if (parseInt($('#noStoreysE31').val()) == parseInt($('#noStoreysE32').val())) {
+            ret_s.s = "Height of ground floor level: invalid range.";
+            return (false);
         }
         else {
             $('#noStoreysE32').removeClass('gem_field_alert');
@@ -2703,6 +2715,10 @@ function taxt_BuildTaxonomy()
             validate_msg += "Date of construction or retrofit: upper limit not positive integer. ";
             $('#DateE2').addClass('gem_field_alert');
             d2 = false;
+        }
+        else if (parseInt($('#DateE1').val()) == parseInt($('#DateE2').val())) {
+            ret_s.s = "Date of construction or retrofit: invalid range.";
+            return (false);
         }
         else {
             $('#DateE2').removeClass('gem_field_alert');
@@ -4019,6 +4035,7 @@ function populate(s, ret_s) {
     var h_cbfun = [ taxt_HeightCB1Select, taxt_HeightCB2Select, taxt_HeightCB3Select, taxt_HeightCB4Select ];
     var h_typck = [ is_not_negative_int, is_not_negative_int, is_not_negative_float, is_not_negative_int ];
     var h_typck_s = [ "positive integer", "positive integer", "positive real", "positive integer" ];
+    var h_convf = [ parseInt, parseInt, parseFloat, parseInt ];
     h = sar[6].split('+');
 
     for (sub_i = 0 ; sub_i < h.length ; sub_i++) {
@@ -4073,6 +4090,10 @@ function populate(s, ret_s) {
             if (h_type == hsfx_bet) {
                 if (!h_typck[h_grp](h_vals[1])) {
                     ret_s.s = h_title[h_grp] + ": higher limit not " + h_typck_s[h_grp] + ". ";
+                    return (false);
+                }
+                else if (h_convf[h_grp](h_vals[0]) == h_convf[h_grp](h_vals[1])) {
+                    ret_s.s = h_title[h_grp] + ": invalid range. ";
                     return (false);
                 }
 
@@ -4149,6 +4170,11 @@ function populate(s, ret_s) {
         if (date_id == 'YBET') {
             if (!is_not_negative_int(date_vals[1])) {
                 ret_s.s = "Date of construction or retrofit: higher limit is not positive integer.";
+                return (false);
+            }
+
+            if (parseInt(date_vals[0]) == parseInt(date_vals[1])) {
+                ret_s.s = "Date of construction or retrofit: invalid range.";
                 return (false);
             }
 

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -609,7 +609,7 @@ function taxt_ValidateHeight() // Ok
     $('#noStoreysE22').prop("disabled", true);
     $('#noStoreysE31').prop("disabled", true);
     $('#noStoreysE32').prop("disabled", true);
-    $('#noStoreysE4').prop("disabled", true);
+    $('#noStoreysE41').prop("disabled", true);
 
     if ($('#HeightCB1').val() > 0) {
         $('#HeightCB2').prop("disabled", false);
@@ -670,10 +670,10 @@ function taxt_ValidateHeight() // Ok
         }
 
         if ($('#HeightCB4').val() == 0) {
-            $('#noStoreysE4').prop("disabled", true);
+            $('#noStoreysE41').prop("disabled", true);
         }
         else {
-            $('#noStoreysE4').prop("disabled", false);
+            $('#noStoreysE41').prop("disabled", false);
         }
     }
     else {
@@ -1903,7 +1903,7 @@ function BuildTaxonomyString(out_type)
         if ($('#HeightCB4').val() == 0 && (out_type == 0))
             Taxonomy[14] = '+HD99';
         if ($('#HeightCB4').val() == 1)
-            Taxonomy[14] = '+HD:' + $('#noStoreysE4').val();
+            Taxonomy[14] = '+HD:' + $('#noStoreysE41').val();
     }
 
     if ($('#OccupancyCB1').val() == 0) {
@@ -2901,7 +2901,7 @@ begin
     if HeightCB3.ItemIndex=3 then Taxonomy[13]:='+HFAPP:'+noStoreysE31.Text;
 
     if (HeightCB4.ItemIndex=1) and (OmitCB.checked = false) then Taxonomy[14]:='+HD99';
-    if HeightCB4.ItemIndex=1 then Taxonomy[14]:='+HD:'+noStoreysE4.Text;
+    if HeightCB4.ItemIndex=1 then Taxonomy[14]:='+HD:'+noStoreysE41.Text;
   end;
 
  if OccupancyCB1.ItemIndex=0 then begin
@@ -3343,7 +3343,7 @@ function taxt_Initiate() {
     select_populate('HeightCB4', HeightCB4);
     $('#HeightCB4').val(0);
     $('#HeightCB4').on('change', taxt_HeightCB4Select);
-    $('#noStoreysE4').on('change', taxt_HeightCB4Select);
+    $('#noStoreysE41').on('change', taxt_HeightCB4Select);
 
     var DateCB1 = [];
     /* Y99  */ DateCB1.push('Year unknown');
@@ -3893,7 +3893,7 @@ function populate(s, ret_s) {
                         ret_s.s = "Height: '" + h_label + "' type requires exactly 1 value, " + is_or_are_given(h_vals.length);
                         return (false);
                     }
-                    $('#noStoreysE4').val(h_vals[0]);
+                    $('#noStoreysE41').val(h_vals[0]);
                     taxt_HeightCB4Select(null);
                 }
                 else {

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -2568,7 +2568,8 @@ function taxt_BuildTaxonomy()
     var ResTax, ResTaxFull = BuildTaxonomyString(0);
     var out_type = $('#OutTypeCB').val();
 
-    /* validation part */
+    /* validation part: '#HeightCBx' are dropdown menus with it's current selected item */
+
     var height1 = $('#HeightCB1').val();
     var height2 = $('#HeightCB2').val();
     var height3 = $('#HeightCB3').val();

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -2696,12 +2696,12 @@ function taxt_BuildTaxonomy()
     }
 
     if (date1 > 0) {
-        if (!is_not_negative_int($('#DateE1').val())) {
-            if (date1 == 1) {
-                validate_msg += "Date of construction or retrofit: lower limit not positive integer. ";
+        if (!is_not_negative_int($('#DateE1').val()) || $('#DateE1').val().length > 4) {
+            if (date1 == 2) {
+                validate_msg += "Date of construction or retrofit: lower limit is not a valid date. ";
             }
             else {
-                validate_msg += "Date of construction or retrofit: not positive integer. ";
+                validate_msg += "Date of construction or retrofit: it is not a valid date. ";
             }
             $('#DateE1').addClass('gem_field_alert');
             d1 = false;
@@ -2711,8 +2711,8 @@ function taxt_BuildTaxonomy()
         }
     }
     if (date1 == 2) {
-        if (!is_not_negative_int($('#DateE2').val())) {
-            validate_msg += "Date of construction or retrofit: upper limit not positive integer. ";
+        if (!is_not_negative_int($('#DateE2').val()) || $('#DateE2').val().length > 4) {
+            validate_msg += "Date of construction or retrofit: upper limit is not a valid date. ";
             $('#DateE2').addClass('gem_field_alert');
             d2 = false;
         }
@@ -4157,19 +4157,19 @@ function populate(s, ret_s) {
             }
         }
 
-        if (!is_not_negative_int(date_vals[0])) {
+        if (!is_not_negative_int(date_vals[0]) || date_vals[0].length > 4) {
             if (date_id == 'YBET') {
-                ret_s.s = "Date of construction or retrofit: lower limit is not positive integer.";
+                ret_s.s = "Date of construction or retrofit: lower limit is not a valid date.";
             }
             else {
-                ret_s.s = "Date of construction or retrofit: it is not positive integer.";
+                ret_s.s = "Date of construction or retrofit: it is not a valid date.";
             }
             return (false);
         }
 
         if (date_id == 'YBET') {
-            if (!is_not_negative_int(date_vals[1])) {
-                ret_s.s = "Date of construction or retrofit: higher limit is not positive integer.";
+            if (!is_not_negative_int(date_vals[1]) || date_vals[1].length > 4) {
+                ret_s.s = "Date of construction or retrofit: higher limit is a valid date.";
                 return (false);
             }
 

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -4128,18 +4128,41 @@ function populate(s, ret_s) {
                 ret_s.s = "Date: '" + date_id + "' type requires exactly 2 values, " + is_or_are_given(date_vals.length);
                 return (false);
             }
-            $('#DateE1').val(date_vals[0]);
-            $('#DateE2').val(date_vals[1]);
-            taxt_HeightCB1Select(null);
         }
         else if (date_id == 'YEX' || date_id == 'YPRE' || date_id == 'YAPP') {
             if (date_vals.length != 1) {
                 ret_s.s = "Date: '" + date_id + "' type requires exactly 1 value, " + is_or_are_given(date_vals.length);
                 return (false);
             }
-            $('#DateE1').val(date_vals[0]);
-            taxt_HeightCB1Select(null);
         }
+
+        if (!is_not_negative_int(date_vals[0])) {
+            if (date_id == 'YBET') {
+                ret_s.s = "Date of construction or retrofit: lower limit is not positive integer.";
+            }
+            else {
+                ret_s.s = "Date of construction or retrofit: it is not positive integer.";
+            }
+            return (false);
+        }
+
+        if (date_id == 'YBET') {
+            if (!is_not_negative_int(date_vals[1])) {
+                ret_s.s = "Date of construction or retrofit: higher limit is not positive integer.";
+                return (false);
+            }
+
+            // swap items if wrong order
+            if (parseInt(date_vals[0]) > parseInt(date_vals[1])) {
+                var swap = date_vals[1];
+                date_vals[1] = date_vals[0];
+                date_vals[0] = swap;
+            }
+            $('#DateE2').val(date_vals[1]);
+        }
+        $('#DateE1').val(date_vals[0]);
+
+        taxt_ValidateDate();
     }
 
     //

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -149,14 +149,14 @@ var taxonomy_form = "";
 
 function is_not_negative_float(s)
 {
-    if (isNaN(parseFloat(s)) || parseFloat(s) < 0.0)
+    if (isNaN(s) || parseFloat(s) < 0.0)
         return false;
     return true;
 }
 
 function is_not_negative_int(s)
 {
-    if (isNaN(parseInt(s)) || parseInt(s) < 0.0 || parseInt(s) != parseFloat(s))
+    if (isNaN(s) || parseInt(s) < 0.0 || parseInt(s) != parseFloat(s))
         return false;
     return true;
 }

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -147,6 +147,20 @@ var floo_conn =
 
 var taxonomy_form = "";
 
+function is_not_negative_float(s)
+{
+    if (isNaN(parseFloat(s)) || parseFloat(s) < 0.0)
+        return false;
+    return true;
+}
+
+function is_not_negative_int(s)
+{
+    if (isNaN(parseInt(s)) || parseInt(s) < 0.0 || parseInt(s) != parseFloat(s))
+        return false;
+    return true;
+}
+
 function ends_with(str, suffix) {
     return str.indexOf(suffix, str.length - suffix.length) !== -1;
 }
@@ -604,12 +618,21 @@ function taxt_ValidateHeight() // Ok
     $('#HeightCB3').prop("disabled", true);
     $('#HeightCB4').prop("disabled", true);
     $('#noStoreysE11').prop("disabled", true);
+    $('#noStoreysE11').removeClass('gem_field_alert');
     $('#noStoreysE12').prop("disabled", true);
+    $('#noStoreysE12').removeClass('gem_field_alert');
+
     $('#noStoreysE21').prop("disabled", true);
+    $('#noStoreysE21').removeClass('gem_field_alert');
     $('#noStoreysE22').prop("disabled", true);
+    $('#noStoreysE22').removeClass('gem_field_alert');
+
     $('#noStoreysE31').prop("disabled", true);
+    $('#noStoreysE31').removeClass('gem_field_alert');
     $('#noStoreysE32').prop("disabled", true);
+    $('#noStoreysE32').removeClass('gem_field_alert');
     $('#noStoreysE41').prop("disabled", true);
+    $('#noStoreysE41').removeClass('gem_field_alert');
 
     if ($('#HeightCB1').val() > 0) {
         $('#HeightCB2').prop("disabled", false);
@@ -2533,16 +2556,152 @@ function taxt_BuildTaxonomy()
     var ResTax, ResTaxFull = BuildTaxonomyString(0);
     var out_type = $('#OutTypeCB').val();
 
-    if (out_type != 0) {
-        ResTax = BuildTaxonomyString(out_type);
+    /* validation part */
+    var height1 = $('#HeightCB1');
+    var height2 = $('#HeightCB2');
+    var height3 = $('#HeightCB3');
+    var height4 = $('#HeightCB4');
+    var validated = false;
+    var validate_msg = "";
+    var h11 = true, h12 = true, h21 = true, h22 = true, h31 = true, h32 = true;
+
+    do {
+        if (height1.val() > 0) {
+            if (!is_not_negative_int($('#noStoreysE11').val())) {
+                if (height1.val() == 1) {
+                    validate_msg = "Number of storey above ground: lower limit not positive integer. ";
+                }
+                else {
+                    validate_msg = validate_msg + "Number of storey above ground: not positive integer. ";
+                }
+                $('#noStoreysE11').addClass('gem_field_alert');
+                h11 = false;
+            }
+            else {
+                $('#noStoreysE11').removeClass('gem_field_alert');
+            }
+        }
+        if (height1.val() == 1) {
+            if (!is_not_negative_int($('#noStoreysE12').val())) {
+                validate_msg = validate_msg + "Number of storey above ground: upper limit not positive integer. ";
+                $('#noStoreysE12').addClass('gem_field_alert');
+                h12 = false;
+            }
+            else {
+                $('#noStoreysE12').removeClass('gem_field_alert');
+            }
+
+            // swap items if wrong order
+            if (h11 && h12) {
+                if (parseInt($('#noStoreysE11').val()) > parseInt($('#noStoreysE12').val())) {
+                    var swap = $('#noStoreysE11').val();
+                    $('#noStoreysE11').val($('#noStoreysE12').val());
+                    $('#noStoreysE12').val(swap);
+                }
+            }
+        }
+
+
+        if (height2.val() > 0) {
+            if (!is_not_negative_int($('#noStoreysE21').val())) {
+                if (height2.val() == 1) {
+                    validate_msg = "Number of storey above ground: lower limit not positive integer. ";
+                }
+                else {
+                    validate_msg = validate_msg + "Number of storey above ground: not positive integer. ";
+                }
+                $('#noStoreysE21').addClass('gem_field_alert');
+                h21 = false;
+            }
+            else {
+                $('#noStoreysE21').removeClass('gem_field_alert');
+            }
+        }
+        if (height2.val() == 1) {
+            if (!is_not_negative_int($('#noStoreysE22').val())) {
+                validate_msg = validate_msg + "Number of storey above ground: upper limit not positive integer. ";
+                $('#noStoreysE22').addClass('gem_field_alert');
+                h22 = false;
+            }
+            else {
+                $('#noStoreysE22').removeClass('gem_field_alert');
+            }
+
+            // swap items if wrong order
+            if (h21 && h22) {
+                if (parseInt($('#noStoreysE21').val()) > parseInt($('#noStoreysE22').val())) {
+                    var swap = $('#noStoreysE21').val();
+                    $('#noStoreysE21').val($('#noStoreysE22').val());
+                    $('#noStoreysE22').val(swap);
+                }
+            }
+        }
+
+
+        if (height3.val() > 0) {
+            if (!is_not_negative_float($('#noStoreysE31').val())) {
+                if (height3.val() == 1) {
+                    validate_msg = "Height of ground floor level: lower limit not positive real";
+                }
+                else {
+                    validate_msg = validate_msg + "Height of ground floor level: not positive real. ";
+                }
+                $('#noStoreysE31').addClass('gem_field_alert');
+            }
+            else {
+                $('#noStoreysE31').removeClass('gem_field_alert');
+            }
+        }
+        if (height3.val() == 1) {
+            if (!is_not_negative_float($('#noStoreysE32').val())) {
+                validate_msg = validate_msg + "Height of ground floor level: upper limit not positive real. ";
+                $('#noStoreysE32').addClass('gem_field_alert');
+            }
+            else {
+                $('#noStoreysE32').removeClass('gem_field_alert');
+            }
+
+            // swap items if wrong order
+            if ($('#noStoreysE31').val() != "" && $('#noStoreysE32').val() != "") {
+                if (parseFloat($('#noStoreysE31').val()) > parseFloat($('#noStoreysE32').val())) {
+                    var swap = $('#noStoreysE31').val();
+                    $('#noStoreysE31').val($('#noStoreysE32').val());
+                    $('#noStoreysE32').val(swap);
+                }
+            }
+        }
+        if (height4.val() > 0) {
+            if (!is_not_negative_int($('#noStoreysE41').val())) {
+                validate_msg = validate_msg + "Slope of the ground: not positive integer. ";
+                $('#noStoreysE41').addClass('gem_field_alert');
+            }
+            else {
+                $('#noStoreysE41').removeClass('gem_field_alert');
+            }
+        }
+
+
+        if (validate_msg == "")
+            validated = true;
+    } while (false);
+
+    if (validated) {
+        if (out_type != 0) {
+            ResTax = BuildTaxonomyString(out_type);
+        }
+        else {
+            ResTax = ResTaxFull;
+        }
+        taxonomy_form = ResTaxFull;
+
+        $('#resultE').val(ResTax);
+        $('#permalink').attr("href", taxt_prefix + "/" +  ResTaxFull);
     }
     else {
-        ResTax = ResTaxFull;
+        taxonomy_form = "";
+        $('#resultE').val(validate_msg);
+        $('#permalink').attr("href", taxt_prefix);
     }
-    taxonomy_form = ResTaxFull;
-
-    $('#resultE').val(ResTax);
-    $('#permalink').attr("href", taxt_prefix + "/" +  ResTaxFull);
 }
 
 
@@ -3806,16 +3965,24 @@ function populate(s, ret_s) {
     //
     //  Height
     //
-    var h, h_first = false, h_items, h_label, h_id, h_vals;
+    var h, h_items, h_label, h_id, h_vals, h_grp;
     var h_map = [ 'H99' , 'HBET' , 'HEX' , 'HAPP' ,
                   'HB99', 'HBBET', 'HBEX', 'HBAPP',
                   'HF99', 'HFBET', 'HFEX', 'HFAPP',
-                  'HD99', 'HD' ]
+                  'HD99',  null  , 'HD' ]
 
     var h_pref = [ 'H', 'HB', 'HF', 'HD' ];
     var h_cbid = [  1 ,   2 ,   3,    4  ];
-    var h_cbfun = [ taxt_HeightCB1Select, taxt_HeightCB2Select, taxt_HeightCB3Select, taxt_HeightCB4Select ];
+    var h_title = [ 'Number of storey above ground',
+                    'Number of storey below ground',
+                    'Height of ground floor level above grade',
+                    'Slope of the ground' ];
 
+    var hsfx_99 = 0, hsfx_bet = 1, hsfx_ex = 2, hsfx_app = 3;
+
+    var h_cbfun = [ taxt_HeightCB1Select, taxt_HeightCB2Select, taxt_HeightCB3Select, taxt_HeightCB4Select ];
+    var h_typck = [ is_not_negative_int, is_not_negative_int, is_not_negative_float, is_not_negative_int ];
+    var h_typck_s = [ "positive integer", "positive integer", "positive real", "positive integer" ];
     h = sar[6].split('+');
 
     for (sub_i = 0 ; sub_i < h.length ; sub_i++) {
@@ -3825,90 +3992,65 @@ function populate(s, ret_s) {
         h_label = h_items[0];
 
         h_id = h_map.indexOf(h_label);
-        h_iddd = Math.floor(h_id / 4);
-        h_idty = h_id % 4;
         if (h_id == -1) {
             ret_s.s = "Height not defined properly.";
             return (false);
         }
+        h_grp = Math.floor(h_id / 4);
+        h_type = h_id % 4;
 
-        $('#HeightCB' + h_cbid[h_iddd]).val(h_idty);
-        if (h_iddd < 3) {
-            if (ends_with(h_label, '99')) {
-                if (h_items.length != 1) {
-                    ret_s.s = "Height: '" + h_label + "' type requires no values, " + is_or_are_given(h_vals.length);
-                    return (false);
-                }
-            }
-            else if (ends_with(h_label, 'BET')) {
-                h_vals = h_items[1].split(',');
-                if (h_vals.length != 2) {
-                    ret_s.s = "Height: '" + h_label + "' type requires exactly 2 values, " + is_or_are_given(h_vals.length);
-                    return (false);
-                }
+        // set value (in the case of 'HD' the real index must be (h_type - 1))
+        $('#HeightCB' + h_cbid[h_grp]).val(h_map[h_id] == 'HD' ? h_type - 1 : h_type);
 
-                $('#noStoreysE' + h_cbid[h_iddd] + '1').val(h_vals[0]);
-                $('#noStoreysE' + h_cbid[h_iddd] + '2').val(h_vals[1]);
-                h_cbfun[h_iddd](null);
-            }
-            else if (ends_with(h_label, 'EX') || ends_with(h_label, 'APP')) {
-                h_vals = h_items[1].split(',');
-                if (h_vals.length != 1) {
-                    ret_s.s = "Height: '" + h_label + "' type requires exactly 1 value, " + is_or_are_given(h_vals.length);
-                    return (false);
-                }
-                $('#noStoreysE' + h_cbid[h_iddd] + '1').val(h_vals[0]);
-                h_cbfun[h_iddd](null);
-                taxt_HeightCB1Select(null);
-            }
-            else {
-                ret_s.s = "Height: '" + h_label + "' type unknown.";
+        if (h_type == hsfx_99) {
+            if (h_items.length != 1) {
+                ret_s.s = "Height: '" + h_label + "' type requires no values, " + is_or_are_given(h_vals.length);
                 return (false);
             }
         }
-        else if (h_iddd == 3) {
-            for (e = 0 ; e < h_slope.length ; e++) {
-                if (h_label == h_slope[e].id) {
-                    $('#HeightCB4').val(e);
-                    taxt_HeightCB4Select(null);
-                    break;
-                }
-            }
-            if (e == h_slope.length) {
-                ret_s.s = "Height: not identified '" + h_label + "' as specification of slope of the ground.";
+        else if (h_type == hsfx_bet) {
+            h_vals = h_items[1].split(',');
+            if (h_vals.length != 2) {
+                ret_s.s = "Height: '" + h_label + "' type requires exactly 2 values, " + is_or_are_given(h_vals.length);
                 return (false);
-            }
-
-            if (ends_with(h_label, '99')) {
-                if (h_items.length != 1) {
-                    h_vals = h_items[1].split(',');
-                    ret_s.s = "Height: '" + h_iddd + "' type requires no values, " + is_or_are_given(h_vals.length);
-                    return (false);
-                }
-            }
-            else {
-                h_vals = h_items[1].split(',');
-                if (h_label == 'HD') {
-                    if (h_vals.length != 1) {
-                        ret_s.s = "Height: '" + h_label + "' type requires exactly 1 value, " + is_or_are_given(h_vals.length);
-                        return (false);
-                    }
-                    $('#noStoreysE41').val(h_vals[0]);
-                    taxt_HeightCB4Select(null);
-                }
-                else {
-                    ret_s.s = "Height: not identified '" + h_label + "' as specification of height.";
-                    return (false);
-                }
             }
         }
         else {
-            ret_s.s = "Height: '" + h_label + "' not yet implemented.";
-            return (false);
+            h_vals = h_items[1].split(',');
+            if (h_vals.length != 1) {
+                ret_s.s = "Height: '" + h_label + "' type requires exactly 2 values, " + is_or_are_given(h_vals.length);
+                return (false);
+            }
         }
 
-        if (h_iddd == 0) {
-            h_first = true;
+        if (h_type != hsfx_99) {
+            // is_not_negative_int || is_not_negative_float
+            if (! h_typck[h_grp](h_vals[0])) {
+                if (h_type == hsfx_bet) {
+                    ret_s.s = h_title[h_grp] + ": lower limit not " + h_typck_s[h_grp] + ". ";
+                }
+                else {
+                    ret_s.s = h_title[h_grp] + ": not " + h_typck_s[h_grp] + ". ";
+                }
+                return (false);
+            }
+            if (h_type == hsfx_bet) {
+                if (!h_typck[h_grp](h_vals[1])) {
+                    ret_s.s = h_title[h_grp] + ": higher limit not " + h_typck_s[h_grp] + ". ";
+                    return (false);
+                }
+
+                // swap items if wrong order
+                if (parseInt(h_vals[0]) > parseInt(h_vals[1])) {
+                    var swap = h_vals[1];
+                    h_vals[0] = h_vals[1];
+                    h_vals[1] = swap;
+                }
+                $('#noStoreysE' + h_cbid[h_grp] + '2').val(h_vals[1]);
+            }
+            $('#noStoreysE' + h_cbid[h_grp] + '1').val(h_vals[0]);
+
+            h_cbfun[h_grp](null);
         }
     }
 

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -154,6 +154,15 @@ function is_not_negative_float(s)
     return true;
 }
 
+function is_in_rect_angle_float(s)
+{
+    if (!is_not_negative_float(s))
+        return false;
+    if (parseFloat(s) > 90.0)
+        return false;
+    return true;
+}
+
 function is_not_negative_int(s)
 {
     if (isNaN(s) || parseInt(s) < 0.0 || parseInt(s) != parseFloat(s))
@@ -2686,8 +2695,8 @@ function taxt_BuildTaxonomy()
         }
     }
     if (height4 > 0) {
-        if (!is_not_negative_int($('#noStoreysE41').val())) {
-            validate_msg += "Slope of the ground: not positive integer. ";
+        if (!is_in_rect_angle_float($('#noStoreysE41').val())) {
+            validate_msg += "Slope of the ground: it is not positive real between 0 and 90. ";
             $('#noStoreysE41').addClass('gem_field_alert');
         }
         else {
@@ -4033,8 +4042,8 @@ function populate(s, ret_s) {
     var hsfx_99 = 0, hsfx_bet = 1, hsfx_ex = 2, hsfx_app = 3;
 
     var h_cbfun = [ taxt_HeightCB1Select, taxt_HeightCB2Select, taxt_HeightCB3Select, taxt_HeightCB4Select ];
-    var h_typck = [ is_not_negative_int, is_not_negative_int, is_not_negative_float, is_not_negative_int ];
-    var h_typck_s = [ "positive integer", "positive integer", "positive real", "positive integer" ];
+    var h_typck = [ is_not_negative_int, is_not_negative_int, is_not_negative_float, is_in_rect_angle_float ];
+    var h_typck_s = [ "positive integer", "positive integer", "positive real", "positive real between 0 and 90" ];
     var h_convf = [ parseInt, parseInt, parseFloat, parseInt ];
     h = sar[6].split('+');
 

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -4079,8 +4079,8 @@ function populate(s, ret_s) {
                 // swap items if wrong order
                 if (parseInt(h_vals[0]) > parseInt(h_vals[1])) {
                     var swap = h_vals[1];
-                    h_vals[0] = h_vals[1];
-                    h_vals[1] = swap;
+                    h_vals[1] = h_vals[0];
+                    h_vals[0] = swap;
                 }
                 $('#noStoreysE' + h_cbid[h_grp] + '2').val(h_vals[1]);
             }

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -2601,8 +2601,9 @@ function taxt_BuildTaxonomy()
             h12 = false;
         }
         else if (parseInt($('#noStoreysE11').val()) == parseInt($('#noStoreysE12').val())) {
-            ret_s.s = "Number of storey above ground: invalid range.";
-            return (false);
+            validate_msg += "Number of storey above ground: invalid range.";
+            $('#noStoreysE12').addClass('gem_field_alert');
+            h12 = false;
         }
         else {
             $('#noStoreysE12').removeClass('gem_field_alert');
@@ -2641,8 +2642,9 @@ function taxt_BuildTaxonomy()
             h22 = false;
         }
         else if (parseInt($('#noStoreysE21').val()) == parseInt($('#noStoreysE22').val())) {
-            ret_s.s = "Number of storey above ground: invalid range.";
-            return (false);
+            validate_msg += "Number of storey above ground: invalid range.";
+            $('#noStoreysE22').addClass('gem_field_alert');
+            h22 = false;
         }
         else {
             $('#noStoreysE22').removeClass('gem_field_alert');
@@ -2667,6 +2669,7 @@ function taxt_BuildTaxonomy()
                 validate_msg += "Height of ground floor level: not positive real. ";
             }
             $('#noStoreysE31').addClass('gem_field_alert');
+            h31 = false;
         }
         else {
             $('#noStoreysE31').removeClass('gem_field_alert');
@@ -2676,17 +2679,19 @@ function taxt_BuildTaxonomy()
         if (!is_not_negative_float($('#noStoreysE32').val())) {
             validate_msg += "Height of ground floor level: upper limit not positive real. ";
             $('#noStoreysE32').addClass('gem_field_alert');
+            h32 = false;
         }
         else if (parseInt($('#noStoreysE31').val()) == parseInt($('#noStoreysE32').val())) {
-            ret_s.s = "Height of ground floor level: invalid range.";
-            return (false);
+            validate_msg += "Height of ground floor level: invalid range.";
+            $('#noStoreysE32').addClass('gem_field_alert');
+            h32 = false;
         }
         else {
             $('#noStoreysE32').removeClass('gem_field_alert');
         }
 
         // swap items if wrong order
-        if ($('#noStoreysE31').val() != "" && $('#noStoreysE32').val() != "") {
+        if (h31 && h32) {
             if (parseFloat($('#noStoreysE31').val()) > parseFloat($('#noStoreysE32').val())) {
                 var swap = $('#noStoreysE31').val();
                 $('#noStoreysE31').val($('#noStoreysE32').val());
@@ -2694,6 +2699,7 @@ function taxt_BuildTaxonomy()
             }
         }
     }
+
     if (height4 > 0) {
         if (!is_in_rect_angle_float($('#noStoreysE41').val())) {
             validate_msg += "Slope of the ground: it is not positive real between 0 and 90. ";

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -3623,7 +3623,7 @@ function taxt_Initiate() {
     /* EWMA */  WallsCB.push('Masonry exterior walls');
     /* EWME */  WallsCB.push('Metal exterior walls');
     /* EWV  */  WallsCB.push('Vegetative exterior walls');
-    /* EWW9 */  WallsCB.push('Wooden exterior walls');
+    /* EWW  */  WallsCB.push('Wooden exterior walls');
     /* EWSL */  WallsCB.push('Stucco finish on light framing for exterior walls');
     /* EWPL */  WallsCB.push('Plastic/vinyl exterior walls, various');
     /* EWCB */  WallsCB.push('Cement-based boards for exterior walls');

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -709,6 +709,9 @@ function taxt_ValidateHeight() // Ok
 
 function taxt_ValidateDate() // Ok
 {
+    $('#DateE1').removeClass('gem_field_alert');
+    $('#DateE2').removeClass('gem_field_alert');
+
     if ($('#DateCB1').val() == 0) {
         $('#DateE1').css('width', '90%');
         $('#DateE1').prop("disabled", true);
@@ -2557,133 +2560,166 @@ function taxt_BuildTaxonomy()
     var out_type = $('#OutTypeCB').val();
 
     /* validation part */
-    var height1 = $('#HeightCB1');
-    var height2 = $('#HeightCB2');
-    var height3 = $('#HeightCB3');
-    var height4 = $('#HeightCB4');
+    var height1 = $('#HeightCB1').val();
+    var height2 = $('#HeightCB2').val();
+    var height3 = $('#HeightCB3').val();
+    var height4 = $('#HeightCB4').val();
+    var date1 = $('#DateCB1').val();
     var validated = false;
     var validate_msg = "";
     var h11 = true, h12 = true, h21 = true, h22 = true, h31 = true, h32 = true;
+    var d1 = true, d2 = true;
 
-    do {
-        if (height1.val() > 0) {
-            if (!is_not_negative_int($('#noStoreysE11').val())) {
-                if (height1.val() == 1) {
-                    validate_msg = "Number of storey above ground: lower limit not positive integer. ";
-                }
-                else {
-                    validate_msg = validate_msg + "Number of storey above ground: not positive integer. ";
-                }
-                $('#noStoreysE11').addClass('gem_field_alert');
-                h11 = false;
+    if (height1 > 0) {
+        if (!is_not_negative_int($('#noStoreysE11').val())) {
+            if (height1 == 1) {
+                validate_msg += "Number of storey above ground: lower limit not positive integer. ";
             }
             else {
-                $('#noStoreysE11').removeClass('gem_field_alert');
+                validate_msg += "Number of storey above ground: not positive integer. ";
+            }
+            $('#noStoreysE11').addClass('gem_field_alert');
+            h11 = false;
+        }
+        else {
+            $('#noStoreysE11').removeClass('gem_field_alert');
+        }
+    }
+    if (height1 == 1) {
+        if (!is_not_negative_int($('#noStoreysE12').val())) {
+            validate_msg += "Number of storey above ground: upper limit not positive integer. ";
+            $('#noStoreysE12').addClass('gem_field_alert');
+            h12 = false;
+        }
+        else {
+            $('#noStoreysE12').removeClass('gem_field_alert');
+        }
+
+        // swap items if wrong order
+        if (h11 && h12) {
+            if (parseInt($('#noStoreysE11').val()) > parseInt($('#noStoreysE12').val())) {
+                var swap = $('#noStoreysE11').val();
+                $('#noStoreysE11').val($('#noStoreysE12').val());
+                $('#noStoreysE12').val(swap);
             }
         }
-        if (height1.val() == 1) {
-            if (!is_not_negative_int($('#noStoreysE12').val())) {
-                validate_msg = validate_msg + "Number of storey above ground: upper limit not positive integer. ";
-                $('#noStoreysE12').addClass('gem_field_alert');
-                h12 = false;
+    }
+
+    if (height2 > 0) {
+        if (!is_not_negative_int($('#noStoreysE21').val())) {
+            if (height2 == 1) {
+                validate_msg += "Number of storey above ground: lower limit not positive integer. ";
             }
             else {
-                $('#noStoreysE12').removeClass('gem_field_alert');
+                validate_msg += "Number of storey above ground: not positive integer. ";
             }
+            $('#noStoreysE21').addClass('gem_field_alert');
+            h21 = false;
+        }
+        else {
+            $('#noStoreysE21').removeClass('gem_field_alert');
+        }
+    }
 
-            // swap items if wrong order
-            if (h11 && h12) {
-                if (parseInt($('#noStoreysE11').val()) > parseInt($('#noStoreysE12').val())) {
-                    var swap = $('#noStoreysE11').val();
-                    $('#noStoreysE11').val($('#noStoreysE12').val());
-                    $('#noStoreysE12').val(swap);
-                }
-            }
+    if (height2 == 1) {
+        if (!is_not_negative_int($('#noStoreysE22').val())) {
+            validate_msg += "Number of storey above ground: upper limit not positive integer. ";
+            $('#noStoreysE22').addClass('gem_field_alert');
+            h22 = false;
+        }
+        else {
+            $('#noStoreysE22').removeClass('gem_field_alert');
         }
 
+        // swap items if wrong order
+        if (h21 && h22) {
+            if (parseInt($('#noStoreysE21').val()) > parseInt($('#noStoreysE22').val())) {
+                var swap = $('#noStoreysE21').val();
+                $('#noStoreysE21').val($('#noStoreysE22').val());
+                $('#noStoreysE22').val(swap);
+            }
+        }
+    }
 
-        if (height2.val() > 0) {
-            if (!is_not_negative_int($('#noStoreysE21').val())) {
-                if (height2.val() == 1) {
-                    validate_msg = "Number of storey above ground: lower limit not positive integer. ";
-                }
-                else {
-                    validate_msg = validate_msg + "Number of storey above ground: not positive integer. ";
-                }
-                $('#noStoreysE21').addClass('gem_field_alert');
-                h21 = false;
+    if (height3 > 0) {
+        if (!is_not_negative_float($('#noStoreysE31').val())) {
+            if (height3 == 1) {
+                validate_msg += "Height of ground floor level: lower limit not positive real";
             }
             else {
-                $('#noStoreysE21').removeClass('gem_field_alert');
+                validate_msg += "Height of ground floor level: not positive real. ";
+            }
+            $('#noStoreysE31').addClass('gem_field_alert');
+        }
+        else {
+            $('#noStoreysE31').removeClass('gem_field_alert');
+        }
+    }
+    if (height3 == 1) {
+        if (!is_not_negative_float($('#noStoreysE32').val())) {
+            validate_msg += "Height of ground floor level: upper limit not positive real. ";
+            $('#noStoreysE32').addClass('gem_field_alert');
+        }
+        else {
+            $('#noStoreysE32').removeClass('gem_field_alert');
+        }
+
+        // swap items if wrong order
+        if ($('#noStoreysE31').val() != "" && $('#noStoreysE32').val() != "") {
+            if (parseFloat($('#noStoreysE31').val()) > parseFloat($('#noStoreysE32').val())) {
+                var swap = $('#noStoreysE31').val();
+                $('#noStoreysE31').val($('#noStoreysE32').val());
+                $('#noStoreysE32').val(swap);
             }
         }
-        if (height2.val() == 1) {
-            if (!is_not_negative_int($('#noStoreysE22').val())) {
-                validate_msg = validate_msg + "Number of storey above ground: upper limit not positive integer. ";
-                $('#noStoreysE22').addClass('gem_field_alert');
-                h22 = false;
+    }
+    if (height4 > 0) {
+        if (!is_not_negative_int($('#noStoreysE41').val())) {
+            validate_msg += "Slope of the ground: not positive integer. ";
+            $('#noStoreysE41').addClass('gem_field_alert');
+        }
+        else {
+            $('#noStoreysE41').removeClass('gem_field_alert');
+        }
+    }
+
+    if (date1 > 0) {
+        if (!is_not_negative_int($('#DateE1').val())) {
+            if (date1 == 1) {
+                validate_msg += "Date of construction or retrofit: lower limit not positive integer. ";
             }
             else {
-                $('#noStoreysE22').removeClass('gem_field_alert');
+                validate_msg += "Date of construction or retrofit: not positive integer. ";
             }
-
-            // swap items if wrong order
-            if (h21 && h22) {
-                if (parseInt($('#noStoreysE21').val()) > parseInt($('#noStoreysE22').val())) {
-                    var swap = $('#noStoreysE21').val();
-                    $('#noStoreysE21').val($('#noStoreysE22').val());
-                    $('#noStoreysE22').val(swap);
-                }
-            }
+            $('#DateE1').addClass('gem_field_alert');
+            d1 = false;
+        }
+        else {
+            $('#DateE1').removeClass('gem_field_alert');
+        }
+    }
+    if (date1 == 2) {
+        if (!is_not_negative_int($('#DateE2').val())) {
+            validate_msg += "Date of construction or retrofit: upper limit not positive integer. ";
+            $('#DateE2').addClass('gem_field_alert');
+            d2 = false;
+        }
+        else {
+            $('#DateE2').removeClass('gem_field_alert');
         }
 
-
-        if (height3.val() > 0) {
-            if (!is_not_negative_float($('#noStoreysE31').val())) {
-                if (height3.val() == 1) {
-                    validate_msg = "Height of ground floor level: lower limit not positive real";
-                }
-                else {
-                    validate_msg = validate_msg + "Height of ground floor level: not positive real. ";
-                }
-                $('#noStoreysE31').addClass('gem_field_alert');
-            }
-            else {
-                $('#noStoreysE31').removeClass('gem_field_alert');
+        // swap items if wrong order
+        if (d1 && d2) {
+            if (parseInt($('#DateE1').val()) > parseInt($('#DateE2').val())) {
+                var swap = $('#DateE1').val();
+                $('#DateE1').val($('#DateE2').val());
+                $('#DateE2').val(swap);
             }
         }
-        if (height3.val() == 1) {
-            if (!is_not_negative_float($('#noStoreysE32').val())) {
-                validate_msg = validate_msg + "Height of ground floor level: upper limit not positive real. ";
-                $('#noStoreysE32').addClass('gem_field_alert');
-            }
-            else {
-                $('#noStoreysE32').removeClass('gem_field_alert');
-            }
+    }
 
-            // swap items if wrong order
-            if ($('#noStoreysE31').val() != "" && $('#noStoreysE32').val() != "") {
-                if (parseFloat($('#noStoreysE31').val()) > parseFloat($('#noStoreysE32').val())) {
-                    var swap = $('#noStoreysE31').val();
-                    $('#noStoreysE31').val($('#noStoreysE32').val());
-                    $('#noStoreysE32').val(swap);
-                }
-            }
-        }
-        if (height4.val() > 0) {
-            if (!is_not_negative_int($('#noStoreysE41').val())) {
-                validate_msg = validate_msg + "Slope of the ground: not positive integer. ";
-                $('#noStoreysE41').addClass('gem_field_alert');
-            }
-            else {
-                $('#noStoreysE41').removeClass('gem_field_alert');
-            }
-        }
-
-
-        if (validate_msg == "")
-            validated = true;
-    } while (false);
+    if (validate_msg == "")
+        validated = true;
 
     if (validated) {
         if (out_type != 0) {

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb.js
@@ -4061,9 +4061,6 @@ function populate(s, ret_s) {
         h_grp = Math.floor(h_id / 4);
         h_type = h_id % 4;
 
-        // set value (in the case of 'HD' the real index must be (h_type - 1))
-        $('#HeightCB' + h_cbid[h_grp]).val(h_map[h_id] == 'HD' ? h_type - 1 : h_type);
-
         if (h_type == hsfx_99) {
             if (h_items.length != 1) {
                 ret_s.s = "Height: '" + h_label + "' type requires no values, " + is_or_are_given(h_vals.length);
@@ -4114,6 +4111,10 @@ function populate(s, ret_s) {
                 }
                 $('#noStoreysE' + h_cbid[h_grp] + '2').val(h_vals[1]);
             }
+
+            // set value (in the case of 'HD' the real index must be (h_type - 1))
+            $('#HeightCB' + h_cbid[h_grp]).val(h_map[h_id] == 'HD' ? h_type - 1 : h_type);
+
             $('#noStoreysE' + h_cbid[h_grp] + '1').val(h_vals[0]);
 
             h_cbfun[h_grp](null);
@@ -4123,7 +4124,7 @@ function populate(s, ret_s) {
     //
     //  Date
     //
-    var date, date_items, date_label, date_id, date_vals;
+    var date, date_index = -1, date_items, date_label, date_id, date_vals;
 
     date = sar[7].split('+');
     date_items = date[0].split(':');
@@ -4136,9 +4137,8 @@ function populate(s, ret_s) {
 
     for (i = 0 ; i < date_type.length ; i++) {
         if (date_label == date_type[i].id) {
+            date_index = i;
             date_id = date_label;
-            $('#DateCB1').val(i);
-            taxt_DateCB1Select(null);
             break;
         }
     }
@@ -4178,7 +4178,7 @@ function populate(s, ret_s) {
 
         if (date_id == 'YBET') {
             if (!is_not_negative_int(date_vals[1]) || date_vals[1].length > 4) {
-                ret_s.s = "Date of construction or retrofit: higher limit is a valid date.";
+                ret_s.s = "Date of construction or retrofit: higher limit is not a valid date.";
                 return (false);
             }
 
@@ -4195,6 +4195,8 @@ function populate(s, ret_s) {
             }
             $('#DateE2').val(date_vals[1]);
         }
+        $('#DateCB1').val(date_index);
+        taxt_DateCB1Select(null);
         $('#DateE1').val(date_vals[0]);
 
         taxt_ValidateDate();

--- a/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb_maps.js
+++ b/openquakeplatform/openquakeplatform/taxtweb/static/taxtweb/js/taxtweb_maps.js
@@ -345,7 +345,7 @@ var wall_type = [
                  { id: 'EWMA', desc: 'Masonry exterior walls' },
                  { id: 'EWME', desc: 'Metal exterior walls' },
                  { id: 'EWV', desc: 'Vegetative exterior walls' },
-                 { id: 'EWW9', desc: 'Wooden exterior walls' },
+                 { id: 'EWW',  desc: 'Wooden exterior walls' },
                  { id: 'EWSL', desc: 'Stucco finish on light framing for exterior walls' },
                  { id: 'EWPL', desc: 'Plastic/vinyl exterior walls, various' },
                  { id: 'EWCB', desc: 'Cement-based boards for exterior walls' },

--- a/openquakeplatform/openquakeplatform/taxtweb/taxonomy_map.py
+++ b/openquakeplatform/openquakeplatform/taxtweb/taxonomy_map.py
@@ -105,7 +105,7 @@ taxonomy_map = { # Direction spec
              'EWMA': 12,
              'EWME': 12,
              'EWV': 12,
-             'EWW9': 12,
+             'EWW': 12,
              'EWSL': 12,
              'EWPL': 12,
              'EWCB': 12,

--- a/openquakeplatform/openquakeplatform/taxtweb/templates/taxtweb/index.html
+++ b/openquakeplatform/openquakeplatform/taxtweb/templates/taxtweb/index.html
@@ -7,6 +7,11 @@
       <link href='{{ STATIC_URL }}taxtweb/font/lato_font.css' rel='stylesheet' type='text/css' />
 <style>
 
+.gem_field_alert {
+    border-color: #ff0000;
+    background-color: #ffa0a0;
+}
+
 body {
     font-family: 'Lato',sans-serif;
     font-size: 13px;
@@ -439,7 +444,7 @@ window.onload = function () {
         </div>
         <div style="position: absolute; bottom: 0px; margin: 8px;" >
             <p>Taxonomy string for this building typology: </p>
-            <p><input id="resultE" type="text" size="80" maxlength="120"></input></p>
+            <p><input id="resultE" type="text" size="80" readonly="true" maxlength="120"></input></p>
             <p>Type of taxonomy: <select id="OutTypeCB"></select>
             &nbsp;&nbsp;&nbsp;&nbsp;<a id="permalink" target="_blank" href="">Permalink</a></p>
         </div>

--- a/openquakeplatform/openquakeplatform/taxtweb/templates/taxtweb/index.html
+++ b/openquakeplatform/openquakeplatform/taxtweb/templates/taxtweb/index.html
@@ -293,7 +293,7 @@ window.onload = function () {
                 </tr><tr>
                     <td><div style="white-space:nowrap;"><input style="width: 90%;" type="text" id="noStoreysE31"><input style="display:none; width: 45%;" type="text" id="noStoreysE32"></div></td>
 
-                    <td><div style="white-space:nowrap;"><input style="width: 90%;" type="text" id="noStoreysE4"></div></td>
+                    <td><div style="white-space:nowrap;"><input style="width: 90%;" type="text" id="noStoreysE41"></div></td>
                </tr></table>
             </div>
             <div class="data-group">


### PR DESCRIPTION
All numerical fields (are all in "Building Information" tab) now are verified in 2 different way:
 - interactively if you compile the form
 - not interactively if you are opening a taxtonomy passing it by part of a URL

**HOW TO TEST IT**
 - open taxtweb and play with "Building Information" tab
 - click on "Permalink" when no field is broken and try to manipulate the resulting new URL
 - placing strings instead of numbers, negative number, float instead of integer and so on.
