### PR TITLE
Irv scale composite indicators

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -17,6 +17,7 @@
 
 $(document).ready(function() {
     $('#cover').remove();
+    $('.alert-unscaled-data').hide();
 });
 
 var layerAttributes;
@@ -34,6 +35,47 @@ var regions = [];
 var baseMapUrl = new L.TileLayer('http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png');
 var app = new OQLeaflet.OQLeafletApp(baseMapUrl);
 var indicatorChildrenKey = [];
+
+function scaleTheData() {
+    // Create a list of primary indicators that need to be scaled
+    // We are not scalling any of the IR indicators
+    var indicatorsToBeScaled = {};
+    for (var i = 0; i < projectDef.children[1].children.length; i++) {
+        for (var j = 0; j < projectDef.children[1].children[i].children.length; j++) {
+            var tempName = projectDef.children[1].children[i].children[j].field;
+            indicatorsToBeScaled[tempName] = {};
+        }
+    }
+
+    // Populate the list with vlaues
+    for (var key in indicatorsToBeScaled) {
+        for (var i = 0; i < layerAttributes.features.length; i++) {
+            var tempRegion = layerAttributes.features[i].properties[selectedRegion];
+            indicatorsToBeScaled[key][tempRegion] = layerAttributes.features[i].properties[key];
+        }
+    }
+
+    for (var k in indicatorsToBeScaled) {
+        scale(indicatorsToBeScaled[k]);
+    }
+
+    // Put values back into the layerAttributes obj
+    for (var key in indicatorsToBeScaled) {
+        for (var i = 0; i < layerAttributes.features.length; i++) {
+            for (var layerAttributesKey in layerAttributes.features[i].properties) {
+                if (key === layerAttributesKey) {
+                    for(var indicatorKey in indicatorsToBeScaled[key]) {
+                        if (layerAttributes.features[i].properties[selectedRegion] == indicatorKey) {
+                            layerAttributes.features[i].properties[layerAttributesKey] = indicatorsToBeScaled[key][indicatorKey];
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // Process the indicators again
+    processIndicators(layerAttributes, sessionProjectDef);
+}
 
 function createIndex(la, index) {
     var indicator = [];
@@ -195,6 +237,7 @@ function processIndicators(layerAttributes, projectDef) {
     //build the theme indicator object
     var themeData = [];
     indicatorInfo = [];
+    var laValuesArray = [];
 
     function generateThemeObject(indicatorObj) {
         var region = indicatorObj.region;
@@ -294,6 +337,8 @@ function processIndicators(layerAttributes, projectDef) {
                                 primaryInversionFactor = 1;
                             }
                             tempValue = tempValue + ((la[o].properties[p2] * primaryInversionFactor) * weight);
+                            // Collect an array of all the values that pass through the loop
+                            laValuesArray.push(la[o].properties[p2]);
                         }
                     }
                 }
@@ -337,6 +382,31 @@ function processIndicators(layerAttributes, projectDef) {
                 indicatorInfo.push({'region':region, 'theme':theme, 'value':tempValue * themeInversionFactor});
             }
         }
+    }
+
+    ////////////////////////////////
+    //// Check for scaled values ///
+    ////////////////////////////////
+
+    Array.prototype.max = function() {
+        return Math.max.apply(null, this);
+    };
+
+    Array.prototype.min = function() {
+        return Math.min.apply(null, this);
+    };
+
+    var maxValue = laValuesArray.max();
+    var minValue = laValuesArray.min();
+
+    if (minValue === 0 && maxValue === 1) {
+        $('.alert-unscaled-data').hide();
+    } else {
+        $('.alert-unscaled-data').show();
+        $('.scaleTheData').click(function() {
+            // Scale the primary indicators
+            scaleTheData();
+        });
     }
 
     for (var p5 = 0; p5 < indicatorInfo.length; p5++) {

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -646,7 +646,7 @@ function processIndicators(layerAttributes, projectDef) {
     }
 
     // Add all primary indicators to selection menu
-    $('#thematic-map-selection').append('<optgroup label="Primary Indicators">');
+    $('#thematic-map-selection').append('<optgroup label="Composite Indicators">');
     for (var ic = 0; ic < allPrimaryIndicators.length; ic++) {
         $('#thematic-map-selection').append('<option>'+allPrimaryIndicators[ic]+'</option>');
     }

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -848,7 +848,7 @@ var startApp = function() {
                     layerFields.push(key);
                 }
 
-                getLayerInfo(layerAttributes);
+                getLayerInfo();
             },
             error: function() {
                 $('#ajaxErrorDialog').empty();
@@ -860,7 +860,7 @@ var startApp = function() {
         });
     });
 
-    function getLayerInfo(layerAttributes) {
+    function getLayerInfo() {
         /*
         // This feature is removed until the proj def format is refactored
         // Get the bounding box

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_primary.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_primary.js
@@ -21,8 +21,6 @@
 /////////////////////////////////////////////////
 
 function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
-    console.log('projectDef:');
-    console.log(projectDef);
     // Find the theme data and create selection dropdown menu
     var themesWithChildren = [];
     var sum = {};
@@ -101,8 +99,6 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
                 data[n][region] = value;
             }
         }
-        console.log('data:');
-        console.log(data);
 
         $('#primary-tab').append('<div id="primary-chart"></div>');
 

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_primary.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_primary.js
@@ -91,10 +91,6 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
             for (var o = 0; o < layerAttributes.features.length; o++) {
                 var field = data[n].plotElement;
                 var value = layerAttributes.features[o].properties[field];
-
-                if (value === null) {
-                    value = 211.309;
-                }
                 var region = layerAttributes.features[o].properties[selectedRegion];
                 data[n][region] = value;
             }

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_primary.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_PCP_primary.js
@@ -21,6 +21,8 @@
 /////////////////////////////////////////////////
 
 function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
+    console.log('projectDef:');
+    console.log(projectDef);
     // Find the theme data and create selection dropdown menu
     var themesWithChildren = [];
     var sum = {};
@@ -74,26 +76,33 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
 
         // Get the data for each selected theme child
         var data = [];
-        // first setup an object with all regions and the plot element
+        // first setup an object with all regions and the plot element and 0 for each value
         var la = layerAttributes.features;
         for (var ia = 0; ia < selectedThemeChildren.length; ia++) {
             var temp = {};
             temp.plotElement = selectedThemeChildren[ia].field;
             for (var s = 0; s < la.length; s++) {
-                var bar = la[s].properties[selectedRegion];
-                temp[bar] = 0;
+                var eachReagion = la[s].properties[selectedRegion];
+                temp[eachReagion] = 0;
             }
             data.push(temp);
         }
 
+        // Poipulate the object created above with values
         for (var n = 0; n < data.length; n++) {
             for (var o = 0; o < layerAttributes.features.length; o++) {
                 var field = data[n].plotElement;
                 var value = layerAttributes.features[o].properties[field];
+
+                if (value === null) {
+                    value = 211.309;
+                }
                 var region = layerAttributes.features[o].properties[selectedRegion];
                 data[n][region] = value;
             }
         }
+        console.log('data:');
+        console.log(data);
 
         $('#primary-tab').append('<div id="primary-chart"></div>');
 

--- a/openquakeplatform/openquakeplatform/templates/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/templates/irv_viewer.html
@@ -88,7 +88,13 @@ IRV - {{block.super}}
     </div>
     <div id="cat-chart"></div>
     <div id="primary-tab">
-      <div>
+      <div id="mainContainer">
+        <div class="alert-unscaled-data">
+          <div class="alert alert-danger" role="alert">
+            The data provided has not been scaled and may not render well in this chart.
+            <button type="button" class="btn btn-danger scaleTheData">Scale the Data</button>
+          </div>
+        </div>
         <p>
           <select id="primary_indicator" name="primary_indicator"></select>
         </p>

--- a/openquakeplatform/openquakeplatform/templates/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/templates/irv_viewer.html
@@ -91,7 +91,7 @@ IRV - {{block.super}}
       <div id="mainContainer">
         <div class="alert-unscaled-data">
           <div class="alert alert-danger" role="alert">
-            The data provided has not been scaled and may not render well in this chart.
+            The data in this project appears to not have been scaled and may not render well in this chart because values of the indicators appear non-commensurate.
             <button type="button" class="btn btn-danger scaleTheData">Scale the Data</button>
           </div>
         </div>

--- a/openquakeplatform/openquakeplatform/templates/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/templates/irv_viewer.html
@@ -72,7 +72,7 @@ IRV - {{block.super}}
       <li id="1" ><a href="#project-def">Project Definition</a></li>
       <li id="2"><a href="#iri-chart">IRI Chart</a></li>
       <li id="3"><a href="#cat-chart">SVI Theme Chart</a></li>
-      <li id="4"><a href="#primary-tab">Primary Indicator Chart</a></li>
+      <li id="4"><a href="#primary-tab">Composite Indicator Chart</a></li>
 
     </ul>
 


### PR DESCRIPTION
This PR includes provides the IRV web application with logic to check that the composite indicators (previously known as the primary indicators) are scaled, and if they are not, provide the user with a warning message and a button that will scale them.

To test this PR, simply load a project that does not have scaled primary indicators, for example the project called 'testing iri small UX improvements'. 
Once the project has loaded, select the primary indicator tab and you should see the warning message like this:

![screen shot 2015-06-15 at 4 40 25 pm](https://cloud.githubusercontent.com/assets/340159/8162405/47c348ee-137d-11e5-91b4-886f214c10f6.png)


After clicking on the button to scale the composite indicators, the composite indicators are scaled, and all the charts are re-rendered.

This PR also renames the primary indicators to composite indicators, per the project owners request.