### PR TITLE
Irv manage incomplete data2

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -421,9 +421,16 @@ function processIndicators(layerAttributes, projectDef) {
     //// Check for null values primary indicators ///
     /////////////////////////////////////////////////
 
+    // Try and remove the warning message on each iteration.
+    try {
+        $('.incompleteData').remove();
+    } catch (e) {
+        // continue
+    }
+
     if (laValuesArray.indexOf(null) > -1) {
         var warningMsg =
-            '<div class="alert alert-danger" role="alert">'+
+            '<div class="alert alert-danger incompleteData" role="alert">'+
                 'The application is not able to render charts for this project because the composite indicator data is incomplete.'+
             '</div>';
 

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -38,7 +38,7 @@ var indicatorChildrenKey = [];
 
 function scaleTheData() {
     // Create a list of primary indicators that need to be scaled
-    // We are not scalling any of the IR indicators
+    // We are not scaling any of the IR indicators
     var indicatorsToBeScaled = {};
     for (var i = 0; i < projectDef.children[1].children.length; i++) {
         for (var j = 0; j < projectDef.children[1].children[i].children.length; j++) {
@@ -47,7 +47,7 @@ function scaleTheData() {
         }
     }
 
-    // Populate the list with vlaues
+    // Populate the list with values
     for (var key in indicatorsToBeScaled) {
         for (var i = 0; i < layerAttributes.features.length; i++) {
             var tempRegion = layerAttributes.features[i].properties[selectedRegion];
@@ -121,7 +121,7 @@ function combineIndicators(nameLookUp, themeObj, JSONthemes) {
         var tempRegion = themeObj[t].region;
         subIndex[tempRegion] = 0;
     }
-    // get some info aobut the themes
+    // get some info about the themes
     var themeKeys = [];
     var themeWeightObj = {};
     for (var u = 0; u < JSONthemes.length; u++) {
@@ -417,6 +417,24 @@ function processIndicators(layerAttributes, projectDef) {
         }
     }
 
+    /////////////////////////////////////////////////
+    //// Check for null values primary indicators ///
+    /////////////////////////////////////////////////
+
+    if (laValuesArray.indexOf(null) > -1) {
+        var warningMsg =
+            '<div class="alert alert-danger" role="alert">'+
+                'The application is not able to render charts for this project because the composite indicator data is incomplete.'+
+            '</div>';
+
+        // Provide warning message if the composite indicator data is incomplete
+        $('#iri-chart').append(warningMsg);
+        $('#cat-chart').append(warningMsg);
+        $('#primary-tab').append(warningMsg);
+        // Stop the function
+        return;
+    }
+
     ////////////////////////////////
     //// Check for scaled values ///
     ////////////////////////////////
@@ -663,11 +681,11 @@ function processIndicators(layerAttributes, projectDef) {
     });
 
     thematicMap(layerAttributes);
-    IRI.plotElement = "IRI"; // Lable within the object
+    IRI.plotElement = "IRI"; // Label within the object
     if (riskIndicators !== undefined) {
-        RI.plotElement = "RI"; // Lable within the object
+        RI.plotElement = "RI"; // Label within the object
     }
-    SVI.plotElement = "SVI"; // Lable within the object
+    SVI.plotElement = "SVI"; // Label within the object
     var iriPcpData = [];
     iriPcpData.push(IRI);
     iriPcpData.push(SVI);
@@ -689,7 +707,7 @@ function scale(IndicatorObj) {
     var tempMin = Math.min.apply(null, ValueArray),
         tempMax = Math.max.apply(null, ValueArray);
     for (var j = 0; j < ValueArray.length; j++) {
-        // make sure not to devide by zero
+        // make sure not to divide by zero
         // 1 is an arbitrary choice to translate a flat array into an array where each element equals to 1
         if (tempMax  == tempMin) {
             ValueArray[j] = 1;


### PR DESCRIPTION
Per the request of the project owner, the charts will no longer be rendered when the composite data is incomplete. We now check for incomplete data, provide a warning message to the user and then stop the function from rendering the charts.

To test this PR, load a project that has incomplete data, you will then seem in each of the chart tabs a warning message like the this: 

![screen shot 2015-06-16 at 12 22 50 pm](https://cloud.githubusercontent.com/assets/340159/8180972/733f1548-1422-11e5-840b-9c82de65d25c.png)

Please note that the tree chart is still visible and the user can still modify weights and save new versions of the project definition. The thematic map is not rendered to the map as the values are also dependent on the composite data. 

