### PR TITLE
Place the thematic map variable into the global scope

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -26,6 +26,7 @@ var selectedRegion;
 var selectedIndicator;
 var selectedLayer;
 var tempProjectDef;
+var thematicLayer;
 //var boundingBox;
 
 // sessionProjectDef is the project definition as is was when uploaded from the QGIS tool.
@@ -731,7 +732,7 @@ function scale(IndicatorObj) {
 }
 
 function thematicMap(layerAttributes) {
-    // Initialise the legend
+    // Initialize the legend
     var legendControl = new L.Control.Legend();
     legendControl.addTo(map);
 
@@ -790,7 +791,7 @@ function thematicMap(layerAttributes) {
         fillColor: yellowToRed
     };
 
-    var thematicLayer = new L.ChoroplethDataLayer(layerAttributes, options);
+    thematicLayer = new L.ChoroplethDataLayer(layerAttributes, options);
     map.addLayer(thematicLayer);
 
     legendControl = new L.Control.Legend();


### PR DESCRIPTION
With the thematic in global scope, the application is able to remove any previously rendered map on each iteration of the block of code. This will prevent the maps overlapping eachother.

You can test this by modifying the web application so that it will render a new map (change weights, inversions, or make a new selection from the map indicator pull down menu. 

You will see that the map layers are not overlapping because the opacity of the map will remain constant (if the maps overlap, then the opacity will appear to change).