### PR TITLE
Update the GeoNode layers template

### DIFF
--- a/openquakeplatform/openquakeplatform/templates/base/resourcebase_info_panel.html
+++ b/openquakeplatform/openquakeplatform/templates/base/resourcebase_info_panel.html
@@ -136,9 +136,9 @@ and overrides the original GeoNode template.
     </li>
   {% endif %}
 
-  {% if resourcebase.supplemental_information %}
+  {% if resourcebase.supplemental_information and resourcebase.category|stringformat:"s" != 'SVIR' %}
     <li>
-      <strong>{% trans "Supplemental Information" %}:</strong> 
+      <strong>{% trans "Supplemental Information" %}:</strong>
       {{ resourcebase.supplemental_information|escape|urlize|linebreaks|safe }}
     </li>
   {% endif %}


### PR DESCRIPTION
Update the GeoNode layers template in order to not show supplemental information when the category is SVIR

I needed to use stringformat in the filter because the category variable in surrounded by whitespace and a simple filter would not work.

To test, in the OQP open a layer the contains the category 'SVIR', you should NOT see the supplemental information metadata field. Then selected another layer that has category 'Hazard' (for example), and you should see the supplemental information metadata field