### PR TITLE
Check the svir plugin version

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -880,6 +880,21 @@ function getGeoServerLayers() {
     });
 }
 
+
+function versionCompare(a, b) {
+    var i, cmp, len, re = /(\.0)+[^\.]*$/;
+    a = (a + '').replace(re, '').split('.');
+    b = (b + '').replace(re, '').split('.');
+    len = Math.min(a.length, b.length);
+    for( i = 0; i < len; i++ ) {
+        cmp = parseInt(a[i], 10) - parseInt(b[i], 10);
+        if( cmp !== 0 ) {
+            return cmp;
+        }
+    }
+    return a.length - b.length;
+}
+
 var startApp = function() {
     // theme tabls behavior
     $('#themeTabs').resizable({
@@ -1033,6 +1048,8 @@ var startApp = function() {
                 });
             }
         });
+
+
         */
         // Get the project definition
         $.ajax({
@@ -1040,6 +1057,20 @@ var startApp = function() {
             url: '../svir/get_project_definitions?layer_name='+ selectedLayer,
             success: function(data) {
                 tempProjectDef = data;
+
+                // Check the svir plugin version
+                var versionCheck = versionCompare(data[0].svir_plugin_version, '1.4.3');
+
+                if (versionCheck < 0) {
+                    // Warn the user and stop the application
+                    $('#projectDef-spinner').hide();
+                    $('#project-def').append(
+                        '<div class="alert alert-danger" role="alert">' +
+                            'The project you are trying to load was created with a version of the SVIR QGIS tool kit that is not compatible with this application' +
+                        '</div>'
+                    );
+                    return
+                }
 
                 if ($('#pdSelection').length > 0) {
                     $('#pdSelection').remove();

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -26,6 +26,7 @@ var selectedRegion;
 var selectedIndicator;
 var selectedLayer;
 var tempProjectDef;
+var COMPATIBILITY_VERSION = '1.4.3';
 //var boundingBox;
 
 // sessionProjectDef is the project definition as is was when uploaded from the QGIS tool.
@@ -1059,7 +1060,7 @@ var startApp = function() {
                 tempProjectDef = data;
 
                 // Check the svir plugin version
-                var versionCheck = versionCompare(data[0].svir_plugin_version, '1.4.3');
+                var versionCheck = versionCompare(data[0].svir_plugin_version, COMPATIBILITY_VERSION);
 
                 if (versionCheck < 0) {
                     // Warn the user and stop the application


### PR DESCRIPTION
Check the svir plugin version, warn the user and stop the application if the version is older than 1.4.3

To test this feature, load a project that has a svir_plugin_version < 1.4.3. 
The application will render a warning message like this:

![screen shot 2015-06-23 at 12 56 51 pm](https://cloud.githubusercontent.com/assets/340159/8304630/037bf86c-19a8-11e5-94f8-7bb85dfb1b69.png)

If a project is loaded into the application with a version => 1.4.3, then the project will be loaded as normal.
