### PR TITLE
Exposure export bug 1469636

### DIFF
--- a/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure_controller.js
+++ b/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure_controller.js
@@ -177,7 +177,6 @@ app.controller('ExposureCountryList', function($scope, $filter, myService, ngTab
                 // Check the grid count
                 if ( $scope.selectedRegion[0].tot_grid_count < 300000) {
                     $('#exposure-building-form').append(
-			'<input type="hidden" name="ph-sr_id" value="'+$scope.selectedRegion[0].study_region_id+'"/>'+
                         '<button id="nationalExposureBldgDownload" type="button">Download</button>'
                     );
                 } else {

--- a/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure_controller.js
+++ b/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure_controller.js
@@ -113,8 +113,10 @@ app.controller('ExposureCountryList', function($scope, $filter, myService, ngTab
 
     // National level building exposure download form
     function nationalForm(study) {
+	var selectedStudy=$scope.selectedRegion[0];
+	console.log("PH: Study=",study,'SelectedStudy=',selectedStudy);
         return '<form id="exposure-building-form" class="exposure_export_form"'+
-                '<p><b>Download Study Wide Building/Dwelling Fractions:</b></p><button id="dwellingFractionsDownload" type="button" value="'+study.study_id+'">Download</button></br></br>'+
+                '<p><b>Download Study Wide Building/Dwelling Fractions:</b></p><button id="dwellingFractionsDownload" type="button" value="'+selectedStudy.study_region_id+'">Download</button></br></br>'+
                 '<b>Download Gridded Building Exposure:</b></br>'+
                 '<p><label for="id_residential_0">Building Type:</label></br>'+
                 '<label for="id_residential_0"><input class="exposure_export_widget" id="id_residential_0" name="residential" type="radio" checked="" value="residential" /> Residential</label></br>'+
@@ -124,9 +126,7 @@ app.controller('ExposureCountryList', function($scope, $filter, myService, ngTab
                 '<label for="id_outputType_0"><input class="exposure_export_widget" id="id_outputType_0" name="outputType" type="radio" checked="" value="csv" /> CSV</label></br>'+
                 '<label for="id_outputType_1"><input class="exposure_export_widget" id="id_outputType_1" name="outputType" type="radio" value="nrml" /> NRML</label></br>'+
                 '</p>'+
-		'<p>Study ID='+study.study_id+' :::: Study Region ID='+$scope.selectedRegion[0].study_region_id+
-                '<input type="hidden" name="old-study" value="'+study.study_id+'">'+
-                '<input type="hidden" name="study" value="'+$scope.selectedRegion[0].study_region_id+'">'+
+                '<input type="hidden" name="study" value="'+selectedStudy.study_region_id+'">'+
                 '<br>'+
             '</form>';
     }

--- a/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure_controller.js
+++ b/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure_controller.js
@@ -114,7 +114,6 @@ app.controller('ExposureCountryList', function($scope, $filter, myService, ngTab
     // National level building exposure download form
     function nationalForm(study) {
 	var selectedStudy=$scope.selectedRegion[0];
-	console.log("PH: Study=",study,'SelectedStudy=',selectedStudy);
         return '<form id="exposure-building-form" class="exposure_export_form"'+
                 '<p><b>Download Study Wide Building/Dwelling Fractions:</b></p><button id="dwellingFractionsDownload" type="button" value="'+selectedStudy.study_region_id+'">Download</button></br></br>'+
                 '<b>Download Gridded Building Exposure:</b></br>'+

--- a/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure_controller.js
+++ b/openquakeplatform/openquakeplatform/exposure/static/exposure/exposure_controller.js
@@ -124,7 +124,9 @@ app.controller('ExposureCountryList', function($scope, $filter, myService, ngTab
                 '<label for="id_outputType_0"><input class="exposure_export_widget" id="id_outputType_0" name="outputType" type="radio" checked="" value="csv" /> CSV</label></br>'+
                 '<label for="id_outputType_1"><input class="exposure_export_widget" id="id_outputType_1" name="outputType" type="radio" value="nrml" /> NRML</label></br>'+
                 '</p>'+
-                '<input type="hidden" name="study" value="'+study.study_id+'">'+
+		'<p>Study ID='+study.study_id+' :::: Study Region ID='+$scope.selectedRegion[0].study_region_id+
+                '<input type="hidden" name="old-study" value="'+study.study_id+'">'+
+                '<input type="hidden" name="study" value="'+$scope.selectedRegion[0].study_region_id+'">'+
                 '<br>'+
             '</form>';
     }
@@ -176,6 +178,7 @@ app.controller('ExposureCountryList', function($scope, $filter, myService, ngTab
                 // Check the grid count
                 if ( $scope.selectedRegion[0].tot_grid_count < 300000) {
                     $('#exposure-building-form').append(
+			'<input type="hidden" name="ph-sr_id" value="'+$scope.selectedRegion[0].study_region_id+'"/>'+
                         '<button id="nationalExposureBldgDownload" type="button">Download</button>'
                     );
                 } else {

--- a/openquakeplatform/openquakeplatform/exposure/templates/exposure/export.html
+++ b/openquakeplatform/openquakeplatform/exposure/templates/exposure/export.html
@@ -45,7 +45,7 @@ Exposure Export {{ block.super }}
           <td data-title="'Name'" filter="{ 'country_name': 'text' }">{{record.country_name}}</td>
           <td data-title="'Number of Studies'">{{record.num_l1_studies}}</td>
           <td data-title="'Study'">{{record.study_name}}</td>
-          <td data-title="'Has Residential'">{{record.has_nonres}}</td>
+          <td data-title="'Has Non-Residential'">{{record.has_nonres}}</td>
         </tr>
       </table>
     </div>

--- a/openquakeplatform/openquakeplatform/exposure/templates/exposure/export.html
+++ b/openquakeplatform/openquakeplatform/exposure/templates/exposure/export.html
@@ -38,7 +38,9 @@ Exposure Export {{ block.super }}
 <div ng-app="exposureApp" >
   <div id="countriesListDialog" title="Admin Level 0 Selection Table">
     <div id="countryList" ng-controller="ExposureCountryList">
+{% endverbatim %}
     <div id="national-spinner" >Loading ...<img id="download-button-spinner" src="{{ STATIC_URL }}img/ajax-loader.gif" /></div>
+{% verbatim %}
       <table ng-table="tableParams" show-filter="true" class="table ng-table-rowselected">
         <tr ng-repeat="record in $data" ng-click="record.$selected = !record.$selected; changeSelection(record)"
                 ng-class="{'active': record.$selected}">
@@ -51,7 +53,9 @@ Exposure Export {{ block.super }}
     </div>
     <div id="subRegionList" ng-controller="ExposureRegionList">
       <div id="ragionTable">
+{% endverbatim %}
       <div id="subnational-spinner" >Loading ...<img id="download-button-spinner" src="{{ STATIC_URL }}img/ajax-loader.gif" /></div>
+{% verbatim %}
         <table ng-table="tableParams2" show-filter="true" class="table ng-table-rowselected">
           <tr ng-repeat="record in $data" ng-click="record.$selected = !record.$selected; changeSelection(record)"
                   ng-class="{'active': record.$selected}">


### PR DESCRIPTION
Fix for launchpad bug 1469636 
 https://bugs.launchpad.net/oq-platform/+bug/1469636

The key issue is that the study_id is passed to export API calls instead of the study_region_id.
This bug was not immediately obvious for two reasons:
*  for many studies (PAGER, most UN Habitat Level 0), study_id==study_region_id
*  the handling for sub-national studies is slightly different

As described in the launchpad bug, all NERA national studies are affected, as as the UN Habitat L0 studies for Mexico, Mongolia, South Africa and Ukraine. 

This pull request replaces study_id with the study_region_id from the selected study region.

In order to confirm that the coordinates are correct, I recommend loading the CSV data into QGIS over an OpenLayers background so as to check that the downloaded area corresponds to the expected region.  

This pull request also resolves two minor presentation problems:
* replaces "Has Residential" label with "Has **Non** Residential"
* resolves 404 error loading spinner image caused by use of Django verbatim directive
