### PR TITLE
Hrde bugs

### DIFF
--- a/openquakeplatform/openquakeplatform/static/css/hrde.css
+++ b/openquakeplatform/openquakeplatform/static/css/hrde.css
@@ -133,7 +133,7 @@ a {
 }
 
 .leaflet-control-layers {
-  width: 350px;
+  width: 450px !important;
 }
 
 .leaflet-control {
@@ -142,12 +142,19 @@ a {
 }
 
 .leaflet-control-layers .leaflet-row .leaflet-input {
-  width: 5%;
+  width: 20px !important;
 }
 
 .leaflet-control-layers .leaflet-row .leaflet-up {
-  padding-right: 20px;
-  float: right;
+  margin-left: 25%;
+}
+
+.leaflet-control-layers-expanded {
+  max-height: 1% !important;
+}
+
+.leaflet-control-layers label {
+  margin-top: 3px;
 }
 
 .leaflet-control-layers .leaflet-row .leaflet-down {

--- a/openquakeplatform/openquakeplatform/static/js/hrde_spectrum_chart_mixed.js
+++ b/openquakeplatform/openquakeplatform/static/js/hrde_spectrum_chart_mixed.js
@@ -77,7 +77,7 @@ function buildMixedSpectrumChart(spectrumCurves, lat, lng) {
         svg.append('path')
             .data([data])
             .attr('class', 'spectrum-line')
-            .style("stroke", colors[count])
+            .style({"stroke": colors[count], "fill": "none"})
             .attr('d', line);
 
         legend.append("text")


### PR DESCRIPTION
This PR solved two small bug in the HRDE.

The first, I have improved the layer control menu. 
To test, open the HRDE app and add some layers (does not matter which laters). If you compare this branch with the current master, you will see that the menu is now far more user friendly. 
Before:

![screen shot 2015-07-22 at 3 49 05 pm](https://cloud.githubusercontent.com/assets/340159/8826793/3b2473d2-3089-11e5-8922-63bd8f585a17.png)

After: 
![screen shot 2015-07-22 at 3 51 50 pm](https://cloud.githubusercontent.com/assets/340159/8826873/be4a1802-3089-11e5-856d-5456049e9fb2.png)


The second resolved issue is when rendering a spectrum code cure the line path was set to 'fill'.
To test, open the HRDE app and open the Europe models, add the 'demo spectrum multiple curves' layer. Then click a feature on the map to render a d3 chart. 

Before: 
![screen shot 2015-07-22 at 3 56 40 pm](https://cloud.githubusercontent.com/assets/340159/8827081/bafeac52-308a-11e5-9af8-6678b532659e.png)

After:
![screen shot 2015-07-22 at 4 00 39 pm](https://cloud.githubusercontent.com/assets/340159/8827094/d7df13ac-308a-11e5-8646-4a6430163570.png)

