### PR TITLE
Irv update tree

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -875,8 +875,8 @@ function getGeoServerLayers() {
         error: function() {
             $('#ajaxErrorDialog').empty();
             $('#ajaxErrorDialog').append(
-                    '<p>This application was not able to get a list of layers from GeoServer</p>'
-                );
+                '<p>This application was not able to get a list of layers from GeoServer</p>'
+            );
             $('#ajaxErrorDialog').dialog('open');
         }
     });
@@ -1017,8 +1017,8 @@ var startApp = function() {
             error: function() {
                 $('#ajaxErrorDialog').empty();
                 $('#ajaxErrorDialog').append(
-                        '<p>This application was not able to get information about the selected layer</p>'
-                    );
+                    '<p>This application was not able to get information about the selected layer</p>'
+                );
                 $('#ajaxErrorDialog').dialog('open');
             }
         });

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -19,6 +19,14 @@
     var CIRCLE_SCALE = 30.0;
     var MAX_STROKE_SIZE = 4.0;
     var MIN_CIRCLE_SIZE = 0.001;
+    var NODE_TYPES = {
+        'IRI': 'Integrated Risk Index',
+        'RI': 'Risk Index',
+        'RISK_INDICATOR': 'Risk Indicator',
+        'SVI': 'Social Vulnerability Index',
+        'SV_THEME': 'Social Vulnerability Theme',
+        'SV_INDICATOR': 'Social Vulnerability Indicator',
+    };
     var projectDefUpdated;
 
     $(document).ready(function() {
@@ -65,7 +73,7 @@
             .projection(function(d) { return [d.y, d.x]; });
 
         function isComputable(node) {
-            if (node.name === 'IRI') {
+            if (node.type === NODE_TYPES.IRI) {
                 if (typeof node.children === 'undefined') {
                     return false;
                 }
@@ -82,7 +90,7 @@
                     return false;
                 }
             }
-            if (node.name === 'SVI') {
+            if (node.type === NODE_TYPES.SVI) {
                 if (typeof node.children === 'undefined') {
                     return false;
                 }
@@ -99,10 +107,12 @@
                     return false;
                 }
             }
-            if (node.name === 'RI' || node.name === 'SVI' ) {
+            if (node.type === NODE_TYPES.RI || node.type === NODE_TYPES.SVI) {
                 if (typeof node.children === 'undefined' || (typeof node.children !== 'undefined' && node.children.length === 0)) {
+                    console.log('false:');
                     return false;
                 } else {
+                    console.log('true:');
                     return true;
                 }
             }

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -24,8 +24,8 @@
         'RI': 'Risk Index',
         'RISK_INDICATOR': 'Risk Indicator',
         'SVI': 'Social Vulnerability Index',
-        'SV_THEME': 'Social Vulnerability Theme',
-        'SV_INDICATOR': 'Social Vulnerability Indicator',
+        'SVI_THEME': 'Social Vulnerability Theme',
+        'SVI_INDICATOR': 'Social Vulnerability Indicator',
     };
     var projectDefUpdated;
 
@@ -107,12 +107,10 @@
                     return false;
                 }
             }
-            if (node.type === NODE_TYPES.RI || node.type === NODE_TYPES.SVI || node.type == 'SVI_THEME') {
+            if (node.type === NODE_TYPES.RI || node.type === NODE_TYPES.SVI || node.type == NODE_TYPES.SVI_THEME) {
                 if (typeof node.children === 'undefined' || (typeof node.children !== 'undefined' && node.children.length === 0)) {
-                    console.log('false:');
                     return false;
                 } else {
-                    console.log('true:');
                     return true;
                 }
             }

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -38,8 +38,6 @@
     ////////////////////////////////////////////
 
     function loadPD(selectedPDef) {
-        console.log('selectedPDef:');
-        console.log(selectedPDef);
 
         // default tab window size
         var winH = 600;
@@ -532,6 +530,13 @@
                     // d.weight is expected to be between 0 and 1
                     // Nodes are displayed as circles of size between 1 and CIRCLE_SCALE
                     return d.weight ? Math.max(getRadius(d), MIN_CIRCLE_SIZE): MIN_CIRCLE_SIZE;
+                })
+                .style("opacity", function(d) {
+                    if (isComputable(d)) {
+                        return 1;
+                    } else {
+                        return 0.3;
+                    }
                 })
                 .style("stroke", function(d) {
                     if (d.isInverted) {

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -64,6 +64,51 @@
         var diagonal = d3.svg.diagonal()
             .projection(function(d) { return [d.y, d.x]; });
 
+        function isComputable(node) {
+            if (node.name === 'IRI') {
+                if (typeof node.children === 'undefined') {
+                    return false;
+                }
+                // check if both RI and SVI are computable
+                var areRiAndSviComputable = true;
+                for (var i = 0; i < node.children.length; i++) {
+                    if (!isComputable(node.children[i])) {
+                        areRiAndSviComputable = false;
+                    }
+                }
+                if (areRiAndSviComputable) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            if (node.name === 'SVI') {
+                if (typeof node.children === 'undefined') {
+                    return false;
+                }
+                // Check if all themes are computable
+                var areAllThemesComputable = true;
+                for (var i = 0; i < node.children.length; i++) {
+                    if (!isComputable(node.children[i])) {
+                        areAllThemesComputable = false;
+                    }
+                }
+                if (areAllThemesComputable) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            if (node.name === 'RI' || node.name === 'SVI' ) {
+                if (typeof node.children === 'undefined' || (typeof node.children !== 'undefined' && node.children.length === 0)) {
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+            return true;
+        }
+
         function createSpinner(id, weight, name, operator, isInverted) {
             pdTempSpinnerIds.push("spinner-"+id);
             $('#projectDefWeightDialog').dialog("open");
@@ -527,6 +572,13 @@
             // Enter any new links at the parent's previous position.
             link.enter().insert("path", "g")
                 .attr("class", "link")
+                .style("opacity", function(d) {
+                    if (isComputable(d.source)) {
+                        return 1;
+                    } else {
+                        return 0.1;
+                    }
+                })
                 .attr("d", function(d) {
                   var o = {x: source.x0, y: source.y0};
                   return diagonal({source: o, target: o});

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -16,8 +16,8 @@
 */
 
     var DEFAULT_OPERATOR = "Weighted sum";
-    var CIRCLE_SCALE = 30;
-    var MAX_STROKE_SIZE = 4;
+    var CIRCLE_SCALE = 30.0;
+    var MAX_STROKE_SIZE = 4.0;
     var MIN_CIRCLE_SIZE = 0.001;
     var projectDefUpdated;
 
@@ -286,15 +286,18 @@
         }
 
         function getRadius(d) {
+            var radius = MIN_CIRCLE_SIZE;
+            if (typeof d.weight != 'undefined') {
+                radius = Math.max(d.weight * CIRCLE_SCALE, MIN_CIRCLE_SIZE);
+            }
             if (typeof d.parent != 'undefined') {
                 if (typeof d.parent.operator != 'undefined') {
                     if (d.parent.operator.indexOf('ignore weights') != -1) {
-                        radius = Math.max(1 / d.parent.children.length * CIRCLE_SCALE, MIN_CIRCLE_SIZE);
-                        return radius;
+                        radius = Math.max(1.0 / d.parent.children.length * CIRCLE_SCALE, MIN_CIRCLE_SIZE);
                     }
                 }
             }
-            return d.weight ? Math.max(d.weight * CIRCLE_SCALE, MIN_CIRCLE_SIZE): MIN_CIRCLE_SIZE;
+            return radius;
         }
 
         function findTreeBranchInfo(pdData, pdName, pdLevel) {
@@ -491,7 +494,7 @@
                     }
                 })
                 .style("stroke-width", function(d) {
-                    return d.weight ? Math.min(getRadius(d) / 2, MAX_STROKE_SIZE): 4;
+                    return d.weight ? Math.min(getRadius(d) / 2.0, MAX_STROKE_SIZE): 4.0;
                 })
                 .style("fill", function(d) {
                     // return d.source ? d.source.linkColor: d.linkColor;

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -38,6 +38,8 @@
     ////////////////////////////////////////////
 
     function loadPD(selectedPDef) {
+        console.log('selectedPDef:');
+        console.log(selectedPDef);
 
         // default tab window size
         var winH = 600;

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -107,7 +107,7 @@
                     return false;
                 }
             }
-            if (node.type === NODE_TYPES.RI || node.type === NODE_TYPES.SVI) {
+            if (node.type === NODE_TYPES.RI || node.type === NODE_TYPES.SVI || node.type == 'SVI_THEME') {
                 if (typeof node.children === 'undefined' || (typeof node.children !== 'undefined' && node.children.length === 0)) {
                     console.log('false:');
                     return false;


### PR DESCRIPTION
This small PR include some styling improvements to the d3js tree chart in the IRV web application. This PR can be tested by loading a project that includes some nodes who's values are not computable into the IRV web app.

Before, the tree chart rendered the nodes and node branches regardless of weather or not the source node values are computable:
![screen shot 2015-07-27 at 11 55 16 am](https://cloud.githubusercontent.com/assets/340159/8903272/10d0f642-3457-11e5-98fc-ee059102c6db.png)

After, If the source node values are not computable, then the node and its branch are rendered with some opacity: 
![screen shot 2015-07-27 at 11 57 17 am](https://cloud.githubusercontent.com/assets/340159/8903296/3843d19a-3457-11e5-8709-42a6e7b0e8f6.png)
 