### PR TITLE
setup.py: update django-chained-selectbox to 0.2.1

### DIFF
--- a/openquakeplatform/setup.py
+++ b/openquakeplatform/setup.py
@@ -75,7 +75,7 @@ setup(
         "django-announcements==1.0.2",
         "django-appconf==0.6",
         "django-chained-multi-checkboxes==0.4",
-        "django-chained-selectbox==0.2",
+        "django-chained-selectbox==0.2.1",
         "django-downloadview==1.2",
         "django-extensions==1.1.1",
         "django-extras==0.3",


### PR DESCRIPTION
This should make Jenkins happy. Currently is broken with the following error:

```
Downloading/unpacking django-chained-selectbox==0.2 (from openquakeplatform==1.2.0-git94300dd)
  Could not find a version that satisfies the requirement django-chained-selectbox==0.2 (from openquakeplatform==1.2.0-git94300dd) (from versions: )
No distributions matching the version for django-chained-selectbox==0.2 (from openquakeplatform==1.2.0-git94300dd)
```

Regression of https://github.com/gem/oq-platform/commit/cb54d19b9c428a0fe134186059cdabf45eaf9b5e