### PR TITLE
Irv conflicting labels

### DIFF
--- a/openquakeplatform/openquakeplatform/static/css/irv_viewer.css
+++ b/openquakeplatform/openquakeplatform/static/css/irv_viewer.css
@@ -33,6 +33,10 @@ svg {
   font: 10px sans-serif;
 }
 
+.tooltip {
+  z-index: 99999;
+}
+
 .domain {
   stroke: gray;
   stroke-width: 2;

--- a/openquakeplatform/openquakeplatform/static/css/irv_viewer.css
+++ b/openquakeplatform/openquakeplatform/static/css/irv_viewer.css
@@ -37,6 +37,11 @@ svg {
   z-index: 99999;
 }
 
+#tool-tip {
+  height: 1px;
+  width: 300px;
+}
+
 .domain {
   stroke: gray;
   stroke-width: 2;

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer.js
@@ -727,7 +727,6 @@ function processIndicators(layerAttributes, projectDef) {
 
     IRI_PCP_Chart(iriPcpData);
 
-    $('#projectDef-spinner').hide();
 
 } // End processIndicators
 

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -458,6 +458,7 @@
                 })
                 .attr("text-anchor", function(d) { return "end"; })
                 .text(function(d) {
+                    // Convert long attribute names text into acronyms
                     if (d.isInverted && d.name.length <= 20) {
                         return "- " + d.name;
                     } else if (d.isInverted && d.name.length > 20) {

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -554,10 +554,12 @@
                 .style("fill", "#0000EE")
                 .attr("x", function(d) {
                     if ( d.field == 'SVI') {
-                        if (getRadius(d) > 15) {
+                        if (getRadius(d) >= 15 && getRadius(d) < 20 ) {
                             return "-4em";
+                        } else if (getRadius(d) >= 20) {
+                            return "-5em";
                         } else {
-                            return "-3  em";
+                            return "-2.7em";
                         };
                     } else{
                         return "-1em";

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -549,7 +549,7 @@
                 .attr("class", "pointer")
                 .style("fill", "#0000EE")
                 .attr("x", function(d) {
-                    if ( d.name == 'SVI') {
+                    if (d.type == NODE_TYPES.SVI) {
                         if (getRadius(d) >= 15 && getRadius(d) < 20 ) {
                             return "-4em";
                         } else if (getRadius(d) >= 20) {
@@ -562,7 +562,7 @@
                     }
                 })
                 .attr("dy", function(d) {
-                    if (typeof d.parent != "undefined" && d.x > d.parent.x && d.name == 'SVI'){
+                    if (typeof d.parent != "undefined" && d.x > d.parent.x && d.type == NODE_TYPES.SVI){
                         return 30;
                     } else if(typeof d.parent != "undefined" && d.x > d.parent.x){
                         return -(getRadius(d) + 5);

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -681,6 +681,7 @@
             }
             $('#projectDefWeight-spinner').remove();
         }
+        $('#projectDef-spinner').hide();
     } //end d3 tree
 
 

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -385,7 +385,7 @@
         // empty any previously drawen chart
         $('#projectDef-tree').empty();
         var svg = d3.select("#projectDef-tree").append("svg")
-            .attr("viewBox", "-60 50 " + winW +" " + winH)
+            .attr("viewBox", "-60 10 " + winW +" " + winH)
             .attr("id", "primary-svg-element")
             .append("svg:g")
             .attr("transform", "translate(" + margin.left + ",5)");
@@ -425,12 +425,6 @@
             // Update the nodes…
             var node = svg.selectAll("g.node")
                 .data(nodes, function(d) { return d.id || (d.id = ++i); });
-
-            // Define 'div' for tooltips
-            var tooltip = d3.select("body")
-                .append("projectDef-tree")
-                .attr("class", "tooltip")
-                .style("opacity", 0);
 
             // Enter any new nodes at the parent's previous position.
             nodeEnter = node.enter().append("g")
@@ -473,35 +467,28 @@
                         return acronym;
                     }
                 })
-                // Tooltip stuff after this NEW
-                .on("mouseover", function(d) {
-                        d3.select(this).select("path").transition()
-                            .duration(200)
-                            .attr("d", arcOver);
-                        textTop.text(d3.select(this).datum().data.label)
-                            .attr("y", -10);
-                        textBottom.text(d3.select(this).datum().data.value.toFixed(3))
-                            .attr("y", 10);
-                    })
+                .attr("font-family", "sans-serif")
+                .attr("font-size", "20px")
+                // Set the color of labels that can be hovered
+                .attr('fill', function(d) {
+                    if (d.name.length > 20) {
+                        return "#003399";
+                    }
+                })
+                // Tooltip for long attribute names
                 .style("fill-opacity", 1e-6)
-                    // Tooltip for primary indicators
                     .on("mouseover", function(d) {
-                        tooltip.transition()
-                            .duration(500)
-                            .style("opacity", 0);
-                        tooltip.transition()
-                            .duration(200)
-                            .style("opacity", .9);
-                        tooltip .text(d.name)
-                            .style("left", (d3.event.pageX) + "px")
-                            .style("top", (d3.event.pageY - 28) + "px");
-                        })
-                    .on("mouseout", function(d) {
-                        tooltip .text("")
-                            .style("left", (d3.event.pageX) + "px")
-                            .style("top", (d3.event.pageY - 28) + "px");
-                        });
-
+                        if (d.name.length > 20) {
+                            d3.select("#tool-tip")
+                                .append("text")
+                                .text(d.name);
+                        }
+                    })
+                    .on("mouseout", function() {
+                        d3.select("#tool-tip")
+                            .select("text")
+                            .remove();
+                    });
             // tree operator label
             nodeEnter.append("text")
                 .text(function(d) {

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -481,7 +481,7 @@
                         if (d.name.length > 20) {
                             d3.select("#tool-tip")
                                 .append("text")
-                                .text(d.name);
+                                .text("Attribute: " + d.name);
                         }
                     })
                     .on("mouseout", function() {

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -451,8 +451,8 @@
                     return "-1em";
                 })
                 .attr("text-anchor", function(d) { return "end"; })
+                // Convert long attribute names text into acronyms
                 .text(function(d) {
-                    // Convert long attribute names text into acronyms
                     if (d.isInverted && d.name.length <= 20) {
                         return "- " + d.name;
                     } else if (d.isInverted && d.name.length > 20) {
@@ -473,6 +473,12 @@
                 .attr('fill', function(d) {
                     if (d.name.length > 20) {
                         return "#003399";
+                    }
+                })
+                // Provide mouse pointer for long attribute names
+                .attr("class", function(d) {
+                    if (d.name.length > 20) {
+                        return "pointer";
                     }
                 })
                 // Tooltip for long attribute names

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -453,18 +453,20 @@
                 .attr("text-anchor", function(d) { return "end"; })
                 // Convert long attribute names text into acronyms
                 .text(function(d) {
-                    if (d.isInverted && d.name.length <= 20) {
-                        return "- " + d.name;
-                    } else if (d.isInverted && d.name.length > 20) {
+                    if (d.name.length > 20) {
                         var matches = d.name.match(/\b(\w)/g);
                         var acronym = matches.join('').toUpperCase();
-                        return "- " + acronym;
-                    } else if (d.name.length <= 20) {
-                        return d.name;
-                    } else if (d.name.length > 20) {
-                        var matches = d.name.match(/\b(\w)/g);
-                        var acronym = matches.join('').toUpperCase();
-                        return acronym;
+                        if (d.isInverted) {
+                            return "- " + acronym;
+                        } else {
+                            return acronym;
+                        }
+                    } else {
+                        if (d.isInverted) {
+                            return "- " + d.name;
+                        } else {
+                            return d.name;
+                        }
                     }
                 })
                 .attr("font-family", "sans-serif")
@@ -547,7 +549,7 @@
                 .attr("class", "pointer")
                 .style("fill", "#0000EE")
                 .attr("x", function(d) {
-                    if ( d.field == 'SVI') {
+                    if ( d.name == 'SVI') {
                         if (getRadius(d) >= 15 && getRadius(d) < 20 ) {
                             return "-4em";
                         } else if (getRadius(d) >= 20) {
@@ -560,7 +562,7 @@
                     }
                 })
                 .attr("dy", function(d) {
-                    if (typeof d.parent != "undefined" && d.x > d.parent.x && d.field == 'SVI'){
+                    if (typeof d.parent != "undefined" && d.x > d.parent.x && d.name == 'SVI'){
                         return 30;
                     } else if(typeof d.parent != "undefined" && d.x > d.parent.x){
                         return -(getRadius(d) + 5);

--- a/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/static/js/irv_viewer_d3_tree.js
@@ -511,9 +511,23 @@
             nodeEnter.append("text")
                 .attr("class", "pointer")
                 .style("fill", "#0000EE")
-                .attr("x", function(d) { return "-1em"; })
+                .attr("x", function(d) {
+                    if ( d.field == 'SVI') {
+                        if (getRadius(d) > 15) {
+                            return "-4em";
+                        } else {
+                            return "-3em";
+                        };
+                    } else{
+                        return "-1em";
+                    }
+                })
                 .attr("dy", function(d) {
-                    if (typeof d.parent != "undefined" && d.x > d.parent.x){
+                    if (typeof d.parent != "undefined" && d.x > d.parent.x && d.field == 'SVI'){
+                        console.log('getRadius(d):');
+                        console.log(getRadius(d));
+                        return 30;
+                    } else if(typeof d.parent != "undefined" && d.x > d.parent.x){
                         return -(getRadius(d) + 5);
                     } else {
                         return getRadius(d) + 12;

--- a/openquakeplatform/openquakeplatform/templates/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/templates/irv_viewer.html
@@ -78,6 +78,7 @@ IRV - {{block.super}}
 
     <div id="project-def">
       <button id="saveBtn" class="btn btn-blue">Save Project Definition</button>
+      <div id="tool-tip"></div>
       <div id="projectDef-tree"></div>
       <div id="projectDefDialog" title="Project Definition">
         <div id="projectDef-spinner" ></div>


### PR DESCRIPTION
This PR provides a number of small UI/UX improvements to the IRV d3js tree chart.
Summary of fixes:
The project definition dialog loading spinner is now hidden only after the tree chart in rendered. This needed when the composite indicator data is incomplete. 

Resolved the labeling conflict between IR and SVI (when SVI has many children)

Resolved labeling issue when attribute label are more then 20 characters. In the case that attribute labels are more then 20 characters, I am substituting the attribute name with an acronym. This acronym can be hovered with the mouse, in which case the full attribute name is rendered on the top left of the dialog. Also note that all labels that can be hovered are rendered in blue, which gives the user a visual clue that it can be interacted with.

Result:
![screen shot 2015-08-04 at 2 42 27 pm](https://cloud.githubusercontent.com/assets/340159/9060924/62379290-3ab8-11e5-94b6-8873acdf0c84.png)
