### PR TITLE
fabfile.py: fix the sequence of importing GS layers

### DIFF
--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -168,14 +168,16 @@ def apps(db_name, db_user, db_pass, geonode_port, geoserver_port, mediaroot):
 
     # reset .json files to original version
     local("for i in $(find -name '*.json.orig'); do mv \"$i\" \"$(echo $i | sed 's/\.orig//g')\" ; done")
-    local("openquakeplatform/bin/oq-gs-builder.sh populate 'openquakeplatform/' 'openquakeplatform/' 'openquakeplatform/bin' 'oqplatform' 'oqplatform' '" + db_name + "' '" + db_user + "' '" + db_pass + "' 'geoserver/data' " + apps_list)
-    local('openquakeplatform/bin/oq-gs-builder.sh drop')
-    local("openquakeplatform/bin/oq-gs-builder.sh restore 'openquakeplatform/build-gs-tree'")
-    local('python manage.py updatelayers')
     local('python manage.py categories_cleanup')
     local('python manage.py loaddata openquakeplatform/common/post_fixtures/*.json')
     local('mkdir -p ' + mediaroot + '/thumbs/')
     local('cp openquakeplatform/common/thumbs/*.png ' + mediaroot + '/thumbs/')
+    # GeoServer stuff must be done after the fixtures have been pushed
+    # to allow syncronization of keywords and metadata from GN to GS
+    local("openquakeplatform/bin/oq-gs-builder.sh populate 'openquakeplatform/' 'openquakeplatform/' 'openquakeplatform/bin' 'oqplatform' 'oqplatform' '" + db_name + "' '" + db_user + "' '" + db_pass + "' 'geoserver/data' " + apps_list)
+    local('openquakeplatform/bin/oq-gs-builder.sh drop')
+    local("openquakeplatform/bin/oq-gs-builder.sh restore 'openquakeplatform/build-gs-tree'")
+    local('python manage.py updatelayers')
 
 
 def clean(db_name=None, db_user=None):

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -173,7 +173,7 @@ def apps(db_name, db_user, db_pass, geonode_port, geoserver_port, mediaroot):
     local('mkdir -p ' + mediaroot + '/thumbs/')
     local('cp openquakeplatform/common/thumbs/*.png ' + mediaroot + '/thumbs/')
     # GeoServer stuff must be done after the fixtures have been pushed
-    # to allow syncronization of keywords and metadata from GN to GS
+    # to allow synchronization of keywords and metadata from GN to GS
     local("openquakeplatform/bin/oq-gs-builder.sh populate 'openquakeplatform/' 'openquakeplatform/' 'openquakeplatform/bin' 'oqplatform' 'oqplatform' '" + db_name + "' '" + db_user + "' '" + db_pass + "' 'geoserver/data' " + apps_list)
     local('openquakeplatform/bin/oq-gs-builder.sh drop')
     local("openquakeplatform/bin/oq-gs-builder.sh restore 'openquakeplatform/build-gs-tree'")

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -171,11 +171,12 @@ def apps(db_name, db_user, db_pass, geonode_port, geoserver_port, mediaroot):
     local("openquakeplatform/bin/oq-gs-builder.sh populate 'openquakeplatform/' 'openquakeplatform/' 'openquakeplatform/bin' 'oqplatform' 'oqplatform' '" + db_name + "' '" + db_user + "' '" + db_pass + "' 'geoserver/data' " + apps_list)
     local('openquakeplatform/bin/oq-gs-builder.sh drop')
     local("openquakeplatform/bin/oq-gs-builder.sh restore 'openquakeplatform/build-gs-tree'")
+    local('python manage.py updatelayers')
     local('python manage.py categories_cleanup')
     local('python manage.py loaddata openquakeplatform/common/post_fixtures/*.json')
     local('mkdir -p ' + mediaroot + '/thumbs/')
     local('cp openquakeplatform/common/thumbs/*.png ' + mediaroot + '/thumbs/')
-    # updatelayers must be done after the fixtures have been pushed
+    # updatelayers must be run again after the fixtures have been pushed
     # to allow synchronization of keywords and metadata from GN to GS
     local('python manage.py updatelayers')
 

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -168,15 +168,15 @@ def apps(db_name, db_user, db_pass, geonode_port, geoserver_port, mediaroot):
 
     # reset .json files to original version
     local("for i in $(find -name '*.json.orig'); do mv \"$i\" \"$(echo $i | sed 's/\.orig//g')\" ; done")
+    local("openquakeplatform/bin/oq-gs-builder.sh populate 'openquakeplatform/' 'openquakeplatform/' 'openquakeplatform/bin' 'oqplatform' 'oqplatform' '" + db_name + "' '" + db_user + "' '" + db_pass + "' 'geoserver/data' " + apps_list)
+    local('openquakeplatform/bin/oq-gs-builder.sh drop')
+    local("openquakeplatform/bin/oq-gs-builder.sh restore 'openquakeplatform/build-gs-tree'")
     local('python manage.py categories_cleanup')
     local('python manage.py loaddata openquakeplatform/common/post_fixtures/*.json')
     local('mkdir -p ' + mediaroot + '/thumbs/')
     local('cp openquakeplatform/common/thumbs/*.png ' + mediaroot + '/thumbs/')
-    # GeoServer stuff must be done after the fixtures have been pushed
+    # updatelayers must be done after the fixtures have been pushed
     # to allow synchronization of keywords and metadata from GN to GS
-    local("openquakeplatform/bin/oq-gs-builder.sh populate 'openquakeplatform/' 'openquakeplatform/' 'openquakeplatform/bin' 'oqplatform' 'oqplatform' '" + db_name + "' '" + db_user + "' '" + db_pass + "' 'geoserver/data' " + apps_list)
-    local('openquakeplatform/bin/oq-gs-builder.sh drop')
-    local("openquakeplatform/bin/oq-gs-builder.sh restore 'openquakeplatform/build-gs-tree'")
     local('python manage.py updatelayers')
 
 


### PR DESCRIPTION
This fixes an issue about keywords and metadata.

With the previous behavior GS was synchronizing with an empty GN: this was causing all the keywords to disappear in GS.

Now the sequence is:
- Load the fixture in the GN database
- Push the GS data
- Synchronize GS data with GN

Unblock https://github.com/gem/oq-platform/pull/449
Tests https://ci.openquake.org/job/zdevel_oq-platform/76/