### PR TITLE
Bootstrapify the style of the physical vulnerability application

### DIFF
--- a/openquakeplatform/openquakeplatform/vulnerability/templates/vulnerability/cart.html
+++ b/openquakeplatform/openquakeplatform/vulnerability/templates/vulnerability/cart.html
@@ -202,7 +202,7 @@ ul.messagelist li {
           <form action="" method="post" style="margin: 0px 0px 0px 0px; padding: 0px;">
             <input type="hidden" name="type_of_assessment" value="{{ type_of_assessment }}">
             <input type="hidden" id="curve_id" name="curve_id" value="{{ curve_id }}">
-            <button type="submit" value="List" title="Go to list of all curves" onclick="this.form.action = '/vulnerability/list';"><i class="icon-list"></i>List</button>
+            <button type="submit" class="btn" value="List" title="Go to list of all curves" onclick="this.form.action = '/vulnerability/list';"><i class="icon-list"></i>List</button>
           </form>
         </li>
         {% if geninfo_user %}
@@ -214,7 +214,7 @@ ul.messagelist li {
         </li>
         <li class="vuln_menu vuln_menu_button" style="float: right;">
           <form action="" method="post" style="margin: 0; padding: 0px;">
-            <button type="submit" value="Empty cart" title="Empty collection of curves." onclick="return empty_check(this);"><i class="icon-trash"></i>Empty cart</button>
+            <button type="submit" class="btn" value="Empty cart" title="Empty collection of curves." onclick="return empty_check(this);"><i class="icon-trash"></i>Empty cart</button>
           </form>
         </li>
         {% endif %}
@@ -235,8 +235,8 @@ ul.messagelist li {
           {% endif %}
           <div id="actions" style="display: none;">
             <form action="" method="post" style="margin: 8px;">
-            <input id="from" type="hidden" name="from"/>            
-            <button type="submit" id="more_details" type="submit" value="More details" title="See more details" name="_show" onclick="return more_details_cb(this);"><span class="icon-search" aria-hidden="true"></span> More details</button>
+            <input id="from" type="hidden" name="from"/>
+            <button type="submit"  class="btn" id="more_details" type="submit" value="More details" title="See more details" name="_show" onclick="return more_details_cb(this);"><span class="icon-search" aria-hidden="true"></span> More details</button>
             </form>
           </div>
           <div id="functionContainer" class="main_app">

--- a/openquakeplatform/openquakeplatform/vulnerability/templates/vulnerability/list.html
+++ b/openquakeplatform/openquakeplatform/vulnerability/templates/vulnerability/list.html
@@ -203,7 +203,7 @@ ul.messagelist li {
         {% for toa_key,toa_value in types_of_assessment.items %}{% if toa_key == type_of_assessment %}<li class="vuln_menu vuln_menu_selected">{{toa_value}}</li>{% else %}<li class="vuln_menu"><a class="vuln_menu" href="?type_of_assessment={{toa_key}}">{{toa_value}}</a></li>{% endif %}{% endfor %}
         <li class="vuln_menu" style="float: right;">
           <form action="/admin/vulnerability/generalinformation/add/" method="GET" style="margin: 0;">
-            <button type="submit" value="New function" title="Create a new function."><span class="icon-pencil" aria-hidden="true"></span> New function</button>
+            <button type="submit" class="btn" value="New function" title="Create a new function."><span class="icon-pencil" aria-hidden="true"></span> New function</button>
           </form>
         </li>
         <li class="vuln_menu" style="float: right;">
@@ -211,7 +211,7 @@ ul.messagelist li {
             <input type="hidden" name="type_of_assessment" value="{{ type_of_assessment }}">
             <input type="hidden" id="curve_id" name="curve_id" value="{{ curve_id }}">
 
-            <button type="submit" value="Cart ({{ cart_numb }})" title="Collection of curves to export as a single NRML file." onclick="this.form.action = '/vulnerability/cart';"><span class="icon-shopping-cart" aria-hidden="true"></span> Cart ({{ cart_numb }})</button>
+            <button type="submit" class="btn" value="Cart ({{ cart_numb }})" title="Collection of curves to export as a single NRML file." onclick="this.form.action = '/vulnerability/cart';"><span class="icon-shopping-cart" aria-hidden="true"></span> Cart ({{ cart_numb }})</button>
           </form>
         </li>
       </ul>
@@ -242,7 +242,7 @@ ul.messagelist li {
               </td>
             {% endfor %}
               <td>
-                <button type="submit" value="Filter"><span class="icon-filter" aria-hidden="true"></span> Filter</button>
+                <button type="submit" class="btn" value="Filter"><span class="icon-filter" aria-hidden="true"></span> Filter</button>
               </td>
             </tr>
           </table>
@@ -264,7 +264,7 @@ ul.messagelist li {
           <div id="actions" style="display: none;">
             <form action="" method="post" style="margin: 8px;">
             <input id="from" type="hidden" name="from"/>
-            <button type="submit" id="more_details" type="submit" value="More details" value="More details" name="_show" onclick="return more_details_cb(this);"><span class="icon-search" aria-hidden="true"></span> More details</button>
+            <button type="submit" class="btn" id="more_details" type="submit" value="More details" value="More details" name="_show" onclick="return more_details_cb(this);"><span class="icon-search" aria-hidden="true"></span> More details</button>
             </form>
            </div>
           <div id="functionContainer" class="main_app">

--- a/openquakeplatform/openquakeplatform/vulnerability/templates/vulnerability/show_general_information.html
+++ b/openquakeplatform/openquakeplatform/vulnerability/templates/vulnerability/show_general_information.html
@@ -147,11 +147,11 @@ td ul.errorlist li {
 
         var back_btn = '<form method="post">'+
                           '<input type="hidden" name="curve_id" value="{{ curve_id }}"/>'+
-                          '<button type="submit" value="Back to {{ from_page }}" title="{{ from_page_info }}" onclick="this.form.action = \'/vulnerability/{{ from_page }}?type_of_assessment={{ type_of_assessment }}\';">'+
+                          '<button class="btn" type="submit" value="Back to {{ from_page }}" title="{{ from_page_info }}" onclick="this.form.action = \'/vulnerability/{{ from_page }}?type_of_assessment={{ type_of_assessment }}\';">'+
                           {% if from_page == 'cart' %}'<span class="icon-shopping-cart' + '" aria-hidden="true"></span> {{ from_page|capfirst }} ({{ cart_curves.count }})</button>'+
                           {% else %}'<span class="icon-list' + '" aria-hidden="true"></span> {{ from_page|capfirst }}</button>'+
                           {% endif %}
-                          ' <button type="submit" value="Back to {{ other_page }}" title="{{ other_page_info }}" onclick="this.form.action = \'/vulnerability/{{ other_page }}\';">'+
+                          ' <button class="btn" type="submit" value="Back to {{ other_page }}" title="{{ other_page_info }}" onclick="this.form.action = \'/vulnerability/{{ other_page }}\';">'+
                           {% if from_page == 'cart' %}'<span class="icon-list' + '" aria-hidden="true"></span> {{ other_page|capfirst }}</button>'+
                           {% else %}' <span class="icon-shopping-cart' + '" aria-hidden="true"></span> {{ other_page|capfirst }} ({{ cart_curves.count }})</button>'+
                           {% endif %}
@@ -159,35 +159,35 @@ td ul.errorlist li {
 
     {% if curve_in_cart %}
         var cartcurve_btn = '<form action="/vulnerability/view/{{ curve_id }}/remove-from-cart" method="post" style="float: right;">'+
-                          '<button type="submit" name="cartcurve" value="Remove from cart" title="remove from collection of curves to export as a single NRML file" ><span class="icon-shopping-cart" aria-hidden="true"></span> Remove</button>'+
+                          '<button class="btn" type="submit" name="cartcurve" value="Remove from cart" title="remove from collection of curves to export as a single NRML file" ><span class="icon-shopping-cart" aria-hidden="true"></span> Remove</button>'+
                         '</form>';
     {% else %}
         var cartcurve_btn = '<form action="/vulnerability/view/{{ curve_id }}/add-to-cart" method="post" style="float: right;">'+
-                          '<button type="submit" name="cartcurve" value="Add to cart" title="add to collection of curves to export as a single NRML file"><span class="icon-shopping-cart" aria-hidden="true"></span> Add</button>'+
+                          '<button class="btn" type="submit" name="cartcurve" value="Add to cart" title="add to collection of curves to export as a single NRML file"><span class="icon-shopping-cart" aria-hidden="true"></span> Add</button>'+
                         '</form>';
     {% endif %}
 
     {% if edit_enabled and from_page == 'list' %}
         var edit_btn = '\
       <form action="/admin/vulnerability/generalinformation/' + gl.pk + '/" method="get">\
-      <button type="submit" value="Edit" title="Edit curve"><span class="icon-edit" aria-hidden="true"></span> Edit</button>\
+      <button class="btn" type="submit" value="Edit" title="Edit curve"><span class="icon-edit" aria-hidden="true"></span> Edit</button>\
       </form>';
     {% else %}
         var edit_btn = '';
     {% endif %}
         var nrml_export_btn = '<form style="float: right;" action="/vulnerability/view/{{ curve_id }}/export-as-nrml" method="post">\
-      <button type="submit" value="Export as NRML" title="Export this curve as NRML"><span class="icon-download-alt" aria-hidden="true"></span> Export as NRML</button>\
+      <button class="btn" type="submit" value="Export as NRML" title="Export this curve as NRML"><span class="icon-download-alt" aria-hidden="true"></span> Export as NRML</button>\
       </form>';
 
         var json_export_btn = '<form style="float: right;" action="#" method="post">\
-      <button type="submit" value="Export as JSON" title="Export this curve as JSON" onClick="var blob = new Blob([ JSON.stringify(gl, null, 4) ], {type: \'application/json;charset=utf-8\'}); saveAs(blob, \'{{ slug_name }}.json\'); return false;"><span class="icon-download-alt" aria-hidden="true"></span> Export as JSON</button>\
+      <button class="btn" type="submit" value="Export as JSON" title="Export this curve as JSON" onClick="var blob = new Blob([ JSON.stringify(gl, null, 4) ], {type: \'application/json;charset=utf-8\'}); saveAs(blob, \'{{ slug_name }}.json\'); return false;"><span class="icon-download-alt" aria-hidden="true"></span> Export as JSON</button>\
       </form>';
 
     {% if from_page == 'list' %}
         var clone_btn = '\
       <form action="/admin/vulnerability/generalinformation/' + gl.pk + '/" method="get">\
       <input type="hidden" name="gem_clone_btn" value="true"/>\
-      <button type="submit" value="Clone" title="Clone as new curve"><span class="icon-pencil" aria-hidden="true"></span> Clone</button>\
+      <button class="btn" type="submit" value="Clone" title="Clone as new curve"><span class="icon-pencil" aria-hidden="true"></span> Clone</button>\
       </form>';
     {% else %}
         var clone_btn = '';

--- a/openquakeplatform/openquakeplatform/vulnerability/templates/vulnerability_submit_line.html
+++ b/openquakeplatform/openquakeplatform/vulnerability/templates/vulnerability_submit_line.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 <div class="submit-row">
-{% if show_back_to_view %}<input type="submit" style="float: left;" value="{% trans 'Back to view' %}" name="_show" onclick="window.open('/vulnerability/view/'+{{ object_id }}+'/', '_self'); return false;"/>{% endif %}
-{% if show_back_to_list %}<input type="submit" style="float: left;" value="{% trans 'Back to list' %}" name="_show" onclick="window.open('/vulnerability/list/', '_self'); return false;"/>{% endif %}
-{% if show_clone %}<input type="submit" value="{% trans 'Clone' %}" name="_clone" {{ onclick_attrib }}/>{% endif %}
-{% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" {{ onclick_attrib }}/>{% endif %}
+{% if show_back_to_view %}<input type="submit" class="btn" style="float: left;" value="{% trans 'Back to view' %}" name="_show" onclick="window.open('/vulnerability/view/'+{{ object_id }}+'/', '_self'); return false;"/>{% endif %}
+{% if show_back_to_list %}<input type="submit" class="btn" style="float: left;" value="{% trans 'Back to list' %}" name="_show" onclick="window.open('/vulnerability/list/', '_self'); return false;"/>{% endif %}
+{% if show_clone %}<input type="submit" class="btn" value="{% trans 'Clone' %}" name="_clone" {{ onclick_attrib }}/>{% endif %}
+{% if show_save %}<input type="submit" class="btn" value="{% trans 'Save' %}" class="default" name="_save" {{ onclick_attrib }}/>{% endif %}
 {% if show_delete_link %}<p class="deletelink-box"><a href="delete/" class="deletelink">{% trans "Delete" %}</a></p>{% endif %}
 {% comment  "we need 'show_save_as_new' enabled for 'clone' button but we don't want to expose 'Save as new' button --" %}
-  {% if show_save_as_new %}<input type="submit" value="{% trans 'Save as new' %}" name="_saveasnew" {{ onclick_attrib }}/>{%endif%} #}
+  {% if show_save_as_new %}<input type="submit" class="btn" value="{% trans 'Save as new' %}" name="_saveasnew" {{ onclick_attrib }}/>{%endif%} #}
 {% endcomment %}
-{% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" name="_addanother" {{ onclick_attrib }} />{% endif %}
-{% if show_save_and_continue %}<input type="submit" value="{% trans 'Save and continue editing' %}" name="_continue" {{ onclick_attrib }}/>{% endif %}
+{% if show_save_and_add_another %}<input type="submit" class="btn" value="{% trans 'Save and add another' %}" name="_addanother" {{ onclick_attrib }} />{% endif %}
+{% if show_save_and_continue %}<input type="submit" class="btn" value="{% trans 'Save and continue editing' %}" name="_continue" {{ onclick_attrib }}/>{% endif %}
 
 </div>


### PR DESCRIPTION


By simply adding `class=“btn”` to html buttons tags, bootstrap will
style the button in a consistent way with the rest of the GeoNode
environment.

Before:
-------

![screen shot 2015-08-18 at 4 06 44 pm](https://cloud.githubusercontent.com/assets/340159/9332085/3b50d50e-45c3-11e5-95cc-ca8dd4147520.png)

and:

![screen shot 2015-08-18 at 4 08 05 pm](https://cloud.githubusercontent.com/assets/340159/9332127/7b9e0a78-45c3-11e5-80b1-19f0097ce27c.png)


After:
------


![screen shot 2015-08-18 at 4 07 04 pm](https://cloud.githubusercontent.com/assets/340159/9332134/851733c2-45c3-11e5-8747-bf6be8cdc32d.png)


and:

![screen shot 2015-08-18 at 4 08 24 pm](https://cloud.githubusercontent.com/assets/340159/9332136/890c5f84-45c3-11e5-9151-2656dac0d8ef.png)

