### PR TITLE
Exposure: add num_l2_studies to the output of get_all_studies API

### DIFF
--- a/openquakeplatform/openquakeplatform/exposure/util.py
+++ b/openquakeplatform/openquakeplatform/exposure/util.py
@@ -88,7 +88,7 @@ SELECT
   FROM (
         -- List of countries with number of sub-national studies
         SELECT grg.g0name, s.id AS study_id,
-               grg.iso, COUNT(sr.id) AS num_l1_studies
+               grg.iso, COUNT(sr.id) AS num_l1_studies,
                COUNT(grg.g2name) AS num_l2_studies
           FROM ged2.geographic_region_gadm grg
           JOIN ged2.study_region sr

--- a/openquakeplatform/openquakeplatform/exposure/util.py
+++ b/openquakeplatform/openquakeplatform/exposure/util.py
@@ -76,7 +76,8 @@ def _get_all_studies():
     """
     query = """\
 SELECT
-  iq.iso, iq.num_l1_studies, iq.study_id, iq.g0name AS country_name,
+  iq.iso, iq.num_l1_studies, iq.num_l2_studies,
+  iq.study_id, iq.g0name AS country_name,
   -- Construct sensible study name
   CASE WHEN s2.notes LIKE '%%PAGER%%'
         THEN 'PAGER national study'
@@ -88,6 +89,7 @@ SELECT
         -- List of countries with number of sub-national studies
         SELECT grg.g0name, s.id AS study_id,
                grg.iso, COUNT(sr.id) AS num_l1_studies
+               COUNT(grg.g2name) AS num_l2_studies
           FROM ged2.geographic_region_gadm grg
           JOIN ged2.study_region sr
             ON sr.geographic_region_id=grg.region_id

--- a/openquakeplatform/openquakeplatform/exposure/views.py
+++ b/openquakeplatform/openquakeplatform/exposure/views.py
@@ -432,7 +432,12 @@ def get_all_studies(request):
     :return: json object containing, for each study, a dictionary with the
              following keys:
              iso: ISO code of the country
-             num_l1_studies: number of level 1 studies
+             num_studies: number of studies
+             num_l1_names: number of level 1 names
+             (NOTE: when level 2 studies are present, num_l1_names is
+                    not the number of level 1 studies)
+             num_l2_names: number of level 2 names
+             (NOTE: it corresponds to the number of level 2 studies)
              country_name: name of the country
              study_name: name of the study
              has_nonres: boolean that indicates if the study has
@@ -441,7 +446,7 @@ def get_all_studies(request):
     studies = []
     StudyRecord = namedtuple(
         'StudyRecord',
-        'iso num_l1_studies num_l2_studies study_id'
+        'iso num_studies num_l1_names num_l2_names study_id'
         ' country_name study_name has_nonres')
     for sr in map(StudyRecord._make, util._get_all_studies()):
         studies.append(dict(sr._asdict()))

--- a/openquakeplatform/openquakeplatform/exposure/views.py
+++ b/openquakeplatform/openquakeplatform/exposure/views.py
@@ -441,7 +441,8 @@ def get_all_studies(request):
     studies = []
     StudyRecord = namedtuple(
         'StudyRecord',
-        'iso num_l1_studies study_id country_name study_name has_nonres')
+        'iso num_l1_studies num_l2_studies study_id'
+        ' country_name study_name has_nonres')
     for sr in map(StudyRecord._make, util._get_all_studies()):
         studies.append(dict(sr._asdict()))
     response_data = json.dumps(studies)

--- a/openquakeplatform/openquakeplatform/exposure/views.py
+++ b/openquakeplatform/openquakeplatform/exposure/views.py
@@ -434,10 +434,11 @@ def get_all_studies(request):
              iso: ISO code of the country
              num_studies: number of studies
              num_l1_names: number of level 1 names
-             (NOTE: when level 2 studies are present, num_l1_names is
-                    not the number of level 1 studies)
+             (NOTE: it corresponds to the number of level 1 studies,
+                    unless higher admin level studies are present)
              num_l2_names: number of level 2 names
-             (NOTE: it corresponds to the number of level 2 studies)
+             (NOTE: it corresponds to the number of level 2 studies,
+                    unless higher admin level studies are present)
              country_name: name of the country
              study_name: name of the study
              has_nonres: boolean that indicates if the study has


### PR DESCRIPTION
Please note that this changes the output of the API. In particular, `num_l1_studies` is not returned anymore. Instead, `num_studies`, `num_l1_names` and `num_l2_names` are returned (please see the new docstring for further details)