### PR TITLE
Angular empty selection bug

### DIFF
--- a/openquakeplatform/openquakeplatform/templates/hrde.html
+++ b/openquakeplatform/openquakeplatform/templates/hrde.html
@@ -55,7 +55,7 @@ HRDE - {{block.super}}
         Filter <input type="text" ng-model="search">
         <br>
         <select id="input-list" size="5" ng-model="selected_input" ng-options="input.name for input in inputs | filter:search | orderBy:'name'">
-          <option value="0"></option>
+          <option style="display:none" value="">select a type</option>
         </select>
         <br>
         <input type="button" id="addTileInput" value="Add Layer">
@@ -68,13 +68,13 @@ HRDE - {{block.super}}
         Filter <input type="text" ng-model="search">
         <br>
         <select size="5" id="layer-list" ng-model="selected_map" ng-options="map.name for map in maps | filter:search | orderBy:'name'">
-          <option></option>
+          <option style="display:none" value="">select a type</option>
         </select>
         <br>
         <input type="button" id="addTileLayer" value="Add Layer">
         <div id="opacity-labels">
-        <p> 
-          <label class="opacity-label" for="amount">Layer opacity:</label> 
+        <p>
+          <label class="opacity-label" for="amount">Layer opacity:</label>
           <input type="text" id="amount" readonly style="width:30px">
         </p>
       </div>
@@ -87,7 +87,9 @@ HRDE - {{block.super}}
         <br>Hazard Curves:<br>
         Filter <input type="text" ng-model="search">
         <br>
-        <select id="curve-list" size="5" ng-model="selected_curve" ng-options="curve.name for curve in curves | filter:search | orderBy:'name'"></select>
+        <select id="curve-list" size="5" ng-model="selected_curve" ng-options="curve.name for curve in curves | filter:search | orderBy:'name'">
+          <option style="display:none" value="">select a type</option>
+        </select>
         <br>
         <input type="button" id="addTileCurve" value="Add Layer">
         <br>
@@ -99,7 +101,9 @@ HRDE - {{block.super}}
         <br>Uniform Hazard Spectra:<br>
         Filter <input type="text" ng-model="search">
         <br>
-        <select id="uhs-list" size="5" ng-model="selected_uhs" ng-options="uhs.name for uhs in uhss | filter:search | orderBy:'name'"></select>
+        <select id="uhs-list" size="5" ng-model="selected_uhs" ng-options="uhs.name for uhs in uhss | filter:search | orderBy:'name'">
+          <option style="display:none" value="">select a type</option>
+        </select>
         <br>
         <input type="button" id="addTileUhs" value="Add Layer">
         <br>
@@ -111,7 +115,9 @@ HRDE - {{block.super}}
         <br>Hazard Spectrum Code:<br>
         Filter <input type="text" ng-model="search">
         <br>
-        <select id="spectrum-list" size="5" ng-model="selected_spectrum" ng-options="spectrum.name for spectrum in spectrums | filter:search | orderBy:'name'"></select>
+        <select id="spectrum-list" size="5" ng-model="selected_spectrum" ng-options="spectrum.name for spectrum in spectrums | filter:search | orderBy:'name'">
+          <option style="display:none" value="">select a type</option>
+        </select>
         <br>
         <input type="button" id="addTileSpectrum" value="Add Layer">
         <br>
@@ -128,7 +134,9 @@ HRDE - {{block.super}}
         <br>Loss Curves<br>
         Filter <input type="text" ng-model="search">
         <br>
-        <select id="loss-list" size="5" ng-model="selected_loss" ng-options="loss.name for loss in losses | filter:search | orderBy:'name'"></select>
+        <select id="loss-list" size="5" ng-model="selected_loss" ng-options="loss.name for loss in losses | filter:search | orderBy:'name'">
+          <option style="display:none" value="">select a type</option>
+        </select>
         <br>
         <input type="button" id="addTileLoss" value="Add Layer">
         <br>

--- a/openquakeplatform/openquakeplatform/templates/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/templates/irv_viewer.html
@@ -60,7 +60,7 @@ IRV - {{block.super}}
       Filter the project list:<br><input type="text" ng-model="search">
       <br><br>
       <select size="5" id="layer-list" ng-model="selected_map" ng-options="map.name for map in maps | filter:search | orderBy:'name'">
-        <option></option>
+        <option style="display:none" value="">select a type</option>
       </select>
       <br>
       <input type="button" id="loadProjectBtn" class="btn btn-blue" disabled="disabled" value="Load Selection">


### PR DESCRIPTION
In the web applications that are using AngularJs for dynamic and responsive selection menus (IRV & HRDE), there is an annoying bug where each menu has an empty option as the first child of selection element. 

![screen shot 2015-09-29 at 11 13 23 am](https://cloud.githubusercontent.com/assets/340159/10159855/29f0e314-669b-11e5-88d6-f384f800f309.png)


This PR includes a fix for this bug as found on the second highest rated answer here: http://stackoverflow.com/questions/12654631/why-does-angularjs-include-an-empty-option-in-select

With this solution the menu now does not include an empty first child element:

![screen shot 2015-09-29 at 11 15 23 am](https://cloud.githubusercontent.com/assets/340159/10160030/89ea8f18-669b-11e5-9785-9392db1b5cf4.png)
