### PR TITLE
fabfile.py: make PYTHON_TEST_LIBS versions explicit

### DIFF
--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -36,7 +36,7 @@ POSTGIS_FILES = [os.path.join(POSTGIS_DIR, f) for f in
 
 DB_PASSWORD = 'openquake'
 
-PYTHON_TEST_LIBS = ['mock', 'nose', 'coverage']
+PYTHON_TEST_LIBS = ['mock==0.7.2', 'nose==1.1.2', 'coverage==3.4']
 
 #: External parametric values
 GEM_GEONODE_PORT = os.getenv('GEM_GEONODE_PORT', '8000')


### PR DESCRIPTION
This fix avoids failures when an isolated venv is used since the latest version of mock is not compatible with the Ubuntu 12.04 setuptools version

```
Downloading/unpacking mock
  Downloading mock-1.3.0.tar.gz (70Kb): 70Kb downloaded
  Running setup.py egg_info for package mock
    mock requires setuptools>=17.1. Aborting installation
    Complete output from command python setup.py egg_info:
    mock requires setuptools>=17.1. Aborting installation
```