### PR TITLE
Risk ipt missing loss category

### DIFF
--- a/openquakeplatform/openquakeplatform/static/js/risk_input_model_fragility.js
+++ b/openquakeplatform/openquakeplatform/static/js/risk_input_model_fragility.js
@@ -204,6 +204,7 @@ $('#saveBtnFF').click(function() {
 
     var functionId = $('#functionId').val();
     var assetCategory = $('#assetCategory').val();
+    var lossCategory = $('#lossCategory').val();
     var functionDescription = $('#functionDescription').val();
 
     /////////////////////////////
@@ -263,7 +264,7 @@ $('#saveBtnFF').click(function() {
     var NRML =
         '<?xml version="1.0" encoding="UTF-8"?> \n' +
         '<nrml xmlns="http://openquake.org/xmlns/nrml/0.5"> \n' +
-            '\t<fragilityModel id="'+functionId+'" assetCategory="'+assetCategory+'"> \n' +
+            '\t<fragilityModel id="'+functionId+'" assetCategory="'+assetCategory+'" lossCategory="'+lossCategory+'"> \n' +
                 '\t\t<description>'+functionDescription+'</description> \n' +
                 limitStatesXML +
                 fragilityFunction +

--- a/openquakeplatform/openquakeplatform/static/js/risk_input_model_fragility.js
+++ b/openquakeplatform/openquakeplatform/static/js/risk_input_model_fragility.js
@@ -250,9 +250,9 @@ $('#saveBtnFF').click(function() {
         for (var i = 0; i < dataFF[k].length; i++) {
             // Dynamic ffs tag(s)
             if (fFormatObj[k] == 'discrete') {
-                ffs += '\t\t\t<poes ls="'+limitStates[i]+'">'+dataFF[k][i][1]+'</poes>\n';
+                ffs += '\t\t\t<poes ls="'+limitStates[i].replace(/ /g,'')+'">'+dataFF[k][i][1]+'</poes>\n';
             } else if (fFormatObj[k] == 'continuous') {
-                ffs += '\t\t\t<params ls="'+limitStates[i]+'" mean="'+dataFF[k][i][1]+'" stddev="'+dataFF[k][i][2]+'"/>\n';
+                ffs += '\t\t\t<params ls="'+limitStates[i].replace(/ /g,'')+'" mean="'+dataFF[k][i][1]+'" stddev="'+dataFF[k][i][2]+'"/>\n';
             }
         }
         // Closing ffs tags

--- a/openquakeplatform/openquakeplatform/templates/risk_input_preparation_toolkit.html
+++ b/openquakeplatform/openquakeplatform/templates/risk_input_preparation_toolkit.html
@@ -149,6 +149,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/agpl.html>.
         <input id="assetCategory" type="text" placeholder="buildings">
       </div>
       <div>
+        <label>Loss Category:</label>
+        <input id="lossCategory" type="text" placeholder="economic">
+      </div>
+      <div>
         <label>Description:</label>
         <textarea id="functionDescription" rows="4" cols="10"></textarea>
       </div>


### PR DESCRIPTION
This Pr fixes 2 small bugs in the Risk input preparation toolkit.
The first bug is that fragility functions did not include the loss category.
The second bug is that there was extra white space in front of the limit states tag for fragility / continuous functions.
