### PR TITLE
Add the RIPT to the AUTH_EXEMPT

### DIFF
--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -363,7 +363,8 @@ AUTH_EXEMPT_URLS = ('/$',
                     '/vulnerability/engineering_demand_csc?.*',
                     '/vulnerability/resp_var_par_csc?.*',
                     '/vulnerability/resp_var_units_csc?.*',
-                    '/taxtweb/')
+                    '/taxtweb/',
+                    '/risk_input_preparation_toolkit/')
 
 # Uncomment to allow open registration.
 # FIXME: there's no admin validation on new accounts.

--- a/openquakeplatform/openquakeplatform/templates/risk_input_preparation_toolkit.html
+++ b/openquakeplatform/openquakeplatform/templates/risk_input_preparation_toolkit.html
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2013, GEM Foundation.
+Copyright (c) 2015, GEM Foundation.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/openquakeplatform/openquakeplatform/templates/risk_input_preparation_toolkit.html
+++ b/openquakeplatform/openquakeplatform/templates/risk_input_preparation_toolkit.html
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/agpl.html>.
 {% load i18n %}
 {% load url from future %}
 
-{% block title %} Explore - {{ block.super }} {% endblock title %}
+{% block title %} Risk Input Preparation Toolkit - {{ block.super }} {% endblock title %}
 
 {% block extra_head %}
     {{block.super}}


### PR DESCRIPTION
This PR adds the Risk Input Preparation Toolkit to the `AUTH_EXEMPT`, thus removing the authentication from it.

This tool does not provide any data (it's just a "converter") and this will reduce the overhead and the noise related to the authentication during the risk workshop.