### PR TITLE
svir: fix filtering indicators by theme

### DIFF
--- a/openquakeplatform/openquakeplatform/svir/views.py
+++ b/openquakeplatform/openquakeplatform/svir/views.py
@@ -397,10 +397,10 @@ def export_variables_info(request):
         indicators = indicators.filter(keywords__in=keywords).distinct()
 
     if theme_obj:
-        if not subtheme_obj:
-            indicators = indicators.filter(theme=theme_obj)
-        else:
+        if subtheme_obj:
             indicators = indicators.filter(subtheme=subtheme_obj)
+        else:
+            indicators = indicators.filter(subtheme__theme=theme_obj)
     elif subtheme_obj:
         indicators = indicators.filter(subtheme=subtheme_obj)
 


### PR DESCRIPTION
Recently, to avoid potential inconsistencies, we changed the `theme` attribute of `Indicator` into a property, so the `Indicator` is directly linked to a `subtheme` and the `subtheme` belongs to one of the `themes`. But we forgot to change one filter, so the API was unable to retrieve indicators belonging to a given `theme` if no `subtheme` was specified. This PR fixes such case.