### PR TITLE
Disable the icebox application

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+python-oq-platform (1.3.1)
+
+  [Daniele Viganò]
+  * Disable the icebox application
+
 python-oq-platform (1.3.0)
 
   [Matteo Nastasi]

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -281,7 +281,7 @@ INSTALLED_APPS = (
     'openquakeplatform.geodetic',
     'openquakeplatform.exposure',
     'openquakeplatform.faulted_earth',
-    'openquakeplatform.icebox',
+    # 'openquakeplatform.icebox',
     'openquakeplatform.vulnerability',
     'openquakeplatform.svir',
     'openquakeplatform.grv',

--- a/openquakeplatform/openquakeplatform/templates/calculate.html
+++ b/openquakeplatform/openquakeplatform/templates/calculate.html
@@ -40,7 +40,6 @@
             <b>Calculate in the cloud:</b>
               <ul>
                 <li>Get an <a href="http://www.globalquakemodel.org/gem/terms/oats/" target="_blank">OATS </a>account to begin using the OpenQuake Engine. An OATS account will allow you to run calculations through a web interface, and the calcualtions and data are in the cloud</li>
-                <li> <a href="{% url 'icebox' %}">Run a demo calculation now</a></li>
               </ul>
             <b>Calculate on a desktop computer or server:</b>
               <ul>

--- a/openquakeplatform/openquakeplatform/urls.py
+++ b/openquakeplatform/openquakeplatform/urls.py
@@ -98,7 +98,6 @@ urlpatterns = patterns('',
 
     (r'^world/', include('openquakeplatform.world.urls')),
     (r'^faulted_earth/', include('openquakeplatform.faulted_earth.urls')),
-    (r'^icebox/', include('openquakeplatform.icebox.urls')),
     (r'^exposure/', include('openquakeplatform.exposure.urls')),
     (r'^svir/', include('openquakeplatform.svir.urls')),
     (r'^vulnerability/', include('openquakeplatform.vulnerability.urls')),
@@ -159,6 +158,11 @@ urlpatterns = patterns('',
     (r'^i18n/', include('django.conf.urls.i18n')),
     (r'^admin/', include(admin.site.urls)),
 
+    )
+
+if 'openquakeplatform.icebox' in settings.INSTALLED_APPS:
+    urlpatterns += patterns('',
+        (r'^icebox/', include('openquakeplatform.icebox.urls')),
     )
 
 # Example of an experimental application


### PR DESCRIPTION
Icebox isn't supported since OpenQuake Engine 1.6. Users can use OATS instead.

Test: https://ci.openquake.org/job/zdevel_oq-platform/185/