### PR TITLE
selenium: make screenshot only if Firefox driver is present

### DIFF
--- a/openquakeplatform/openquakeplatform/test/oqplatform.py
+++ b/openquakeplatform/openquakeplatform/test/oqplatform.py
@@ -323,6 +323,10 @@ class Platform(object):
         wait_for(link_has_gone_stale)
 
     def screenshot(self, filename):
+        if not self.driver:
+            sys.stderr.write(
+                "Platform not initialized, screenshot impossible.\n")
+            return
         self.driver.get_screenshot_as_file(filename)
 
     def add_click_event(self):


### PR DESCRIPTION
...in order to avoid hiding an error message caused by missing config