### PR TITLE
nose: customization of result lines output

### DIFF
--- a/openquakeplatform/openquakeplatform/test/failurecatcher.py
+++ b/openquakeplatform/openquakeplatform/test/failurecatcher.py
@@ -48,3 +48,6 @@ class FailureCatcher(Plugin):
         from openquakeplatform.test import pla
         self.alert_manager(pla)
         pla.screenshot('%s_%s.png' % (self.prefix, test.id()))
+
+    def describeTest(self, test):
+        return "%s" % test.id()


### PR DESCRIPTION
Tests are green: https://ci.openquake.org/job/zdevel_oq-platform/201
from: 
```
test_allowed_methods (openquakeplatform.exposure.tests.DecoratorUtilTestcase) ... ok
test_sign_in_required (openquakeplatform.exposure.tests.DecoratorUtilTestcase) ... ok
test_invalid (openquakeplatform.exposure.tests.ExportAreaValidTestCase) ... ok
...
```
to:
```
openquakeplatform.test.dumb_test.DumbTest.dumb_test ... ok
openquakeplatform.test.irv_test.IrvTest.irv_test ... ok
openquakeplatform.test.isc_test.IscTest.isc_test ... ok
...
```
output.
