### PR TITLE
IRV: use api check for unique name

### DIFF
--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -41,7 +41,7 @@ var VERTICES_THRESHOLD = 500000;
 
 var mappingLayerAttributes = {};
 
-// sessionProjectDef is the project definition as is was when uploaded from the QGIS tool.
+// sessionProjectDef is the project definition as it was when uploaded from the QGIS tool.
 // While projectDef includes modified weights and is no longer the version that was uploaded from the QGIS tool
 var projectLayerAttributes;
 var regions = [];
@@ -1272,7 +1272,7 @@ function watchForPdSelection() {
                 $('#iri-spinner').hide();
                 $('#project-definition-svg').show();
                 // TODO this is required beasue watchForPdSelection is running before the
-                // ajax call are able to get a repley, need to find a better solution
+                // ajax call are able to get a reply, need to find a better solution
                 setTimeout(function() {
                     processIndicators(layerAttributes, sessionProjectDef);
                 }, 3000);

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -155,7 +155,6 @@
 
         $('#submitPD').attr('disabled',true);
 
-        var isSubmitting = false;
         $('#saveBtn').click(function() {
             $('#checkboxPD').attr('checked', false);
             $('#saveState-spinner').hide();
@@ -181,66 +180,66 @@
                     $('#submitPD').attr('disabled', true);
                 }
             });
+        });
 
-            $('#submitPD').click(function() {
-                $('#submitPD').attr('disabled',true);
-                $('#checkboxPD').attr('checked', false);
-                $('#saveState-spinner').show();
-                var inputVal = $('#giveNamePD').val();
-                if (inputVal === '' || inputVal === null) {
-                    $('#ajaxErrorDialog').empty();
-                    $('#ajaxErrorDialog').append(
-                        '<p>A valid name was not provided</p>'
-                    );
-                    $('#ajaxErrorDialog').dialog('open');
-                    $('#saveState-spinner').hide();
-                } else {
-                    projectDefUpdated.title = inputVal;
-                    // Append projectDefUpdated to tempProjectDef
+        var isSubmitting = false;
+        $('#submitPD').click(function() {
+            $('#submitPD').attr('disabled',true);
+            $('#checkboxPD').attr('checked', false);
+            $('#saveState-spinner').show();
+            var inputNamePD = $('#giveNamePD').val();
+            if (inputNamePD === '' || inputNamePD === null) {
+                $('#ajaxErrorDialog').empty();
+                $('#ajaxErrorDialog').append(
+                    '<p>A valid name was not provided</p>'
+                );
+                $('#ajaxErrorDialog').dialog('open');
+                $('#saveState-spinner').hide();
+            } else {
+                projectDefUpdated.title = inputNamePD;
 
-                    var projectDefStg = JSON.stringify(projectDefUpdated, function(key, value) {
-                        //avoid circularity in JSON by removing the parent key
-                        if (key == "parent") {
-                            return 'undefined';
-                        }
-                        return value;
-                    });
-
-                    // prevent multiple AJAX calls
-                    if (isSubmitting) {
-                        return;
+                var projectDefStg = JSON.stringify(projectDefUpdated, function(key, value) {
+                    //avoid circularity in JSON by removing the parent key
+                    if (key == "parent") {
+                        return 'undefined';
                     }
-                    isSubmitting = true;
+                    return value;
+                });
 
-                    // Hit the API endpoint and grab the very very latest version of the PD object
-                    $.post( "../svir/add_project_definition", {
-                        layer_name: selectedLayer,
-                        project_definition: projectDefStg
-                        },
-                        function() {
-                        }).done(function() {
-                            tempProjectDef.push(projectDefUpdated);
-                            isSubmitting = false;
-                            $('#saveStateDialog').dialog('close');
-                            $('#saveState-spinner').hide();
-                            $('#saveBtn').prop('disabled', true);
-                            // append the new element into the dropdown menu
-                            $('#pdSelection').append('<option value="'+ inputVal +'">'+ inputVal +'</option>');
-                            // access the last or newest element in the dropdown menu
-                            var lastValue = $('#pdSelection option:last-child').val();
-                            // select the newest element in the dropdown menu
-                            $('#pdSelection').val(lastValue);
-                        }).fail(function(resp) {
-                            isSubmitting = false;
-                            $('#ajaxErrorDialog').empty();
-                            var error_msg = "<p>This application was not able to write the project definition to the database:</p><p>" + resp.responseText + "</p>";
-                            $('#ajaxErrorDialog').append(error_msg);
-                            $('#ajaxErrorDialog').dialog('open');
-                            $('#submitPD').attr('disabled',true);
-                            $('#saveState-spinner').hide();
-                    });
+                // prevent multiple AJAX calls
+                if (isSubmitting) {
+                    return;
                 }
-            });
+                isSubmitting = true;
+
+                // Hit the API endpoint and grab the very very latest version of the PD object
+                $.post( "../svir/add_project_definition", {
+                    layer_name: selectedLayer,
+                    project_definition: projectDefStg
+                    },
+                    function() {
+                    }).done(function() {
+                        tempProjectDef.push(projectDefStg);
+                        $('#saveStateDialog').dialog('close');
+                        $('#saveState-spinner').hide();
+                        $('#saveBtn').prop('disabled', true);
+                        // append the new element into the dropdown menu
+                        $('#pdSelection').append('<option value="'+ inputNamePD +'">'+ inputNamePD +'</option>');
+                        // access the last or newest element in the dropdown menu
+                        var lastValue = $('#pdSelection option:last-child').val();
+                        // select the newest element in the dropdown menu
+                        $('#pdSelection').val(lastValue);
+                        isSubmitting = false;
+                    }).fail(function(resp) {
+                        $('#ajaxErrorDialog').empty();
+                        var error_msg = "<p>This application was not able to write the project definition to the database:</p><p>" + resp.responseText + "</p>";
+                        $('#ajaxErrorDialog').append(error_msg);
+                        $('#ajaxErrorDialog').dialog('open');
+                        $('#submitPD').attr('disabled',true);
+                        $('#saveState-spinner').hide();
+                        isSubmitting = false;
+                });
+            }
         });
 
         var nodeEnter;

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -196,33 +196,13 @@
                     $('#saveState-spinner').hide();
                 } else {
                     projectDefUpdated.title = inputVal;
-
                     // Append projectDefUpdated to tempProjectDef
-                    // Check for existing object
-                    var duplicate = false;
-                    for (var i = 0; i < tempProjectDef.length; i++) {
-                        if (projectDefUpdated.title == tempProjectDef[i].title) {
-                            duplicate = true;
-                        }
-                    }
-
-                    if (duplicate === false) {
-                        tempProjectDef.push(projectDefUpdated);
-                    } else {
-                        $('#ajaxErrorDialog').empty();
-                        $('#ajaxErrorDialog').append(
-                            '<p>That name is already used to describe another project definition</p>'
-                        );
-                        $('#ajaxErrorDialog').dialog('open');
-                        $('#saveState-spinner').hide();
-                        return;
-                    }
 
                     var projectDefStg = JSON.stringify(projectDefUpdated, function(key, value) {
                         //avoid circularity in JSON by removing the parent key
                         if (key == "parent") {
                             return 'undefined';
-                          }
+                        }
                         return value;
                     });
 
@@ -239,6 +219,7 @@
                         },
                         function() {
                         }).done(function() {
+                            tempProjectDef.push(projectDefUpdated);
                             isSubmitting = false;
                             $('#saveStateDialog').dialog('close');
                             $('#saveState-spinner').hide();
@@ -249,14 +230,14 @@
                             var lastValue = $('#pdSelection option:last-child').val();
                             // select the newest element in the dropdown menu
                             $('#pdSelection').val(lastValue);
-                        }).fail(function() {
+                        }).fail(function(resp) {
                             isSubmitting = false;
                             $('#ajaxErrorDialog').empty();
-                            $('#ajaxErrorDialog').append(
-                                '<p>This application was not able to write the project definition to the database</p>'
-                            );
+                            var error_msg = "<p>This application was not able to write the project definition to the database:</p><p>" + resp.responseText + "</p>";
+                            $('#ajaxErrorDialog').append(error_msg);
                             $('#ajaxErrorDialog').dialog('open');
                             $('#submitPD').attr('disabled',true);
+                            $('#saveState-spinner').hide();
                     });
                 }
             });

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -39,38 +39,6 @@
         });
     });
 
-    // Post New Project Definition
-    function addProjectDefinition() {}
-
-    addProjectDefinition.send = function(selectedLayer, projectDefStg) {
-        // Hit the API endpoint and grab the very very latest version of the PD object
-        $.ajax({
-            method: "POST",
-            url: "../svir/add_project_definition",
-            data: [selectedLayer, projectDefStg]
-        }).done(function() {
-                isSubmitting = false;
-                $('#saveStateDialog').dialog('close');
-                $('#saveState-spinner').hide();
-                $('#saveBtn').prop('disabled', true);
-                // append the new element into the dropdown menu
-                $('#pdSelection').append('<option value="'+ inputVal +'">'+ inputVal +'</option>');
-                // access the last or newest element in the dropdown menu
-                var lastValue = $('#pdSelection option:last-child').val();
-                // select the newest element in the dropdown menu
-                $("#pdSelection").val(lastValue);
-            }).fail(function() {
-                isSubmitting = false;
-                $('#ajaxErrorDialog').empty();
-                $('#ajaxErrorDialog').append(
-                    '<p>This application was not able to write the project definition to the database</p>'
-                );
-                $('#ajaxErrorDialog').dialog('open');
-                $('#submitPD').attr('disabled',true);
-        });
-    };
-
-
     ////////////////////////////////////////////
     //// Project Definition Collapsible Tree ///
     ////////////////////////////////////////////
@@ -126,8 +94,8 @@
                 }
                 // Check if all themes are computable
                 var areAllThemesComputable = true;
-                for (var i = 0; i < node.children.length; i++) {
-                    if (!isComputable(node.children[i])) {
+                for (var childIdx = 0; childIdx < node.children.length; childIdx++) {
+                    if (!isComputable(node.children[childIdx])) {
                         areAllThemesComputable = false;
                     }
                 }
@@ -621,7 +589,7 @@
                             return "-5em";
                         } else {
                             return "-2.7em";
-                        };
+                        }
                     } else{
                         return "-1em";
                     }


### PR DESCRIPTION
Addressing points 1 and 3 of #540, removing some unused code and fixing some minor details that caused warnings by my syntax checker.

The `addProjectDefinition` function was not used anywhere, and exactly the same code was already used elsewhere, so I kept only the other (used) block.

The main change made by this PR is to leverage the `svir/add_project_definition` API to check the uniqueness of the name assigned to the new project definition. The IRV app was doing the same check, which was redundant and has been therefore removed.