### PR TITLE
IRV - Fix the selection of newly added project definitions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,13 @@
   * Improved selenium test suite with users and secondary profiles
     management
 
+  [Paolo Tormene]
+  * irv: fix a bug in the addition of new project definitions, enabling
+    to select the added items and removing some delays
+  * irv: when adding a new project definition, leverage the svir api to check for
+    the uniqueness of the project definition title
+  * irv: let the d3 tree layout look like in the QGIS IRMT plugin
+
 python-oq-platform (1.3.1)
 
   [Daniele Viganò]

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -33,7 +33,6 @@ var thematicLayer;
 var leafletBoundingBox = [];
 var mapboxBoundingBox = [];
 var license;
-var projectDefUpdated;
 var webGl;
 var projectChange = false;
 var verticesCount = 0;
@@ -1258,27 +1257,21 @@ function thematicMapCreation() {
     $('#absoluteSpinner').hide();
 }
 
-function watchForPdSelection() {
+function whenProjDefSelected() {
+    $('#pdSelection').prop("disabled", true);
     $('#projectDef-spinner').show();
-    setTimeout(function() {
-        var pdSelection = $('#pdSelection').val();
-
-        for (var i = 0; i < tempProjectDef.length; i++) {
-            if (tempProjectDef[i].title === pdSelection) {
-                // Deep copy the temp project definition object
-                sessionProjectDef = jQuery.extend(true, {}, tempProjectDef[i]);
-                loadPD(sessionProjectDef);
-
-                $('#iri-spinner').hide();
-                $('#project-definition-svg').show();
-                // TODO this is required because watchForPdSelection is running before the
-                // ajax call are able to get a reply, need to find a better solution
-                setTimeout(function() {
-                    processIndicators(layerAttributes, sessionProjectDef);
-                }, 3000);
-            }
+    var pdSelection = $('#pdSelection').val();
+    for (var i = 0; i < tempProjectDef.length; i++) {
+        if (tempProjectDef[i].title === pdSelection) {
+            // Deep copy the temp project definition object
+            sessionProjectDef = jQuery.extend(true, {}, tempProjectDef[i]);
+            loadPD(sessionProjectDef);
+            $('#iri-spinner').hide();
+            $('#project-definition-svg').show();
+            processIndicators(layerAttributes, sessionProjectDef);
         }
-    }, 100);
+    }
+    $('#pdSelection').prop("disabled", false);
 }
 
 function getGeoServerLayers() {
@@ -1741,7 +1734,7 @@ function projDefJSONRequest(selectedLayer) {
             }
 
             // Create the pd selection menu
-            $('#project-def').prepend('<select id="pdSelection" onChange="watchForPdSelection();"><option value"" disabled selected>Select a Project Definition</option></select>');
+            $('#project-def').prepend('<select id="pdSelection" onChange="whenProjDefSelected();"><option value"" disabled selected>Select a Project Definition</option></select>');
             var pdTitles = [];
 
             // break the array into objects, present the user with a choice of PDs

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1271,7 +1271,7 @@ function watchForPdSelection() {
 
                 $('#iri-spinner').hide();
                 $('#project-definition-svg').show();
-                // TODO this is required beasue watchForPdSelection is running before the
+                // TODO this is required because watchForPdSelection is running before the
                 // ajax call are able to get a reply, need to find a better solution
                 setTimeout(function() {
                     processIndicators(layerAttributes, sessionProjectDef);

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1258,7 +1258,6 @@ function thematicMapCreation() {
 }
 
 function whenProjDefSelected() {
-    $('#pdSelection').prop("disabled", true);
     $('#projectDef-spinner').show();
     var pdSelection = $('#pdSelection').val();
     for (var i = 0; i < tempProjectDef.length; i++) {
@@ -1271,7 +1270,6 @@ function whenProjDefSelected() {
             processIndicators(layerAttributes, sessionProjectDef);
         }
     }
-    $('#pdSelection').prop("disabled", false);
 }
 
 function getGeoServerLayers() {

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -27,6 +27,7 @@
         'SV_THEME': 'Social Vulnerability Theme',
         'SV_INDICATOR': 'Social Vulnerability Indicator'
     };
+    var projectDefUpdated;
 
     $(document).ready(function() {
         //  Project definition weight dialog
@@ -193,65 +194,6 @@
             });
         });
 
-        var isSubmitting = false;
-        $('#submitPD').click(function() {
-            $('#submitPD').attr('disabled',true);
-            $('#checkboxPD').attr('checked', false);
-            $('#saveState-spinner').show();
-            var inputNamePD = $('#giveNamePD').val();
-            if (inputNamePD === '' || inputNamePD === null) {
-                $('#ajaxErrorDialog').empty();
-                $('#ajaxErrorDialog').append(
-                    '<p>A valid name was not provided</p>'
-                );
-                $('#ajaxErrorDialog').dialog('open');
-                $('#saveState-spinner').hide();
-            } else {
-                projectDefUpdated.title = inputNamePD;
-
-                var projectDefStg = JSON.stringify(projectDefUpdated, function(key, value) {
-                    //avoid circularity in JSON by removing the parent key
-                    if (key == "parent") {
-                        return 'undefined';
-                    }
-                    return value;
-                });
-
-                // prevent multiple AJAX calls
-                if (isSubmitting) {
-                    return;
-                }
-                isSubmitting = true;
-
-                // Hit the API endpoint and grab the very very latest version of the PD object
-                $.post( "../svir/add_project_definition", {
-                    layer_name: selectedLayer,
-                    project_definition: projectDefStg
-                    },
-                    function() {
-                    }).done(function() {
-                        tempProjectDef.push(JSON.parse(projectDefStg));
-                        $('#saveStateDialog').dialog('close');
-                        $('#saveState-spinner').hide();
-                        $('#saveBtn').prop('disabled', true);
-                        // append the new element into the dropdown menu
-                        $('#pdSelection').append('<option value="'+ inputNamePD +'">'+ inputNamePD +'</option>');
-                        // access the last or newest element in the dropdown menu
-                        var lastValue = $('#pdSelection option:last-child').val();
-                        // select the newest element in the dropdown menu
-                        $('#pdSelection').val(lastValue);
-                        isSubmitting = false;
-                    }).fail(function(resp) {
-                        $('#ajaxErrorDialog').empty();
-                        var error_msg = "<p>This application was not able to write the project definition to the database:</p><p>" + resp.responseText + "</p>";
-                        $('#ajaxErrorDialog').append(error_msg);
-                        $('#ajaxErrorDialog').dialog('open');
-                        $('#submitPD').attr('disabled',true);
-                        $('#saveState-spinner').hide();
-                        isSubmitting = false;
-                });
-            }
-        });
 
         function updateButton() {
             $('#projectDefWeightDialog').append('<br/><br/><button type="button" id="update-spinner-value" class="btn btn-blue">Update</button>');
@@ -696,4 +638,53 @@
         $('#projectDef-spinner').hide();
     } //end d3 tree
 
+    $('#submitPD').click(function () {
+        $('#submitPD').attr('disabled',true);
+        $('#checkboxPD').attr('checked', false);
+        $('#saveState-spinner').show();
+        var inputNamePD = $('#giveNamePD').val();
+        if (inputNamePD === '' || inputNamePD === null) {
+            $('#ajaxErrorDialog').empty();
+            $('#ajaxErrorDialog').append(
+                '<p>A valid name was not provided</p>'
+            );
+            $('#ajaxErrorDialog').dialog('open');
+            $('#saveState-spinner').hide();
+        } else {
+            projectDefUpdated.title = inputNamePD;
 
+            var projectDefStg = JSON.stringify(projectDefUpdated, function(key, value) {
+                //avoid circularity in JSON by removing the parent key
+                if (key == "parent") {
+                    return 'undefined';
+                }
+                return value;
+            });
+
+            // Hit the API endpoint and grab the very very latest version of the PD object
+            $.post( "../svir/add_project_definition", {
+                layer_name: selectedLayer,
+                project_definition: projectDefStg
+                },
+                function() {
+                }).done(function() {
+                    tempProjectDef.push(JSON.parse(projectDefStg));
+                    $('#saveStateDialog').dialog('close');
+                    $('#saveState-spinner').hide();
+                    $('#saveBtn').prop('disabled', true);
+                    // append the new element into the dropdown menu
+                    $('#pdSelection').append('<option value="'+ inputNamePD +'">'+ inputNamePD +'</option>');
+                    // access the last or newest element in the dropdown menu
+                    var lastValue = $('#pdSelection option:last-child').val();
+                    // select the newest element in the dropdown menu
+                    $('#pdSelection').val(lastValue);
+                }).fail(function(resp) {
+                    $('#ajaxErrorDialog').empty();
+                    var error_msg = "<p>This application was not able to write the project definition to the database:</p><p>" + resp.responseText + "</p>";
+                    $('#ajaxErrorDialog').append(error_msg);
+                    $('#ajaxErrorDialog').dialog('open');
+                    $('#submitPD').attr('disabled',true);
+                    $('#saveState-spinner').hide();
+            });
+        }
+    });

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -368,7 +368,7 @@
 
         d3.select(self.frameElement).style("height", "800px");
 
-        function onTreeElementClick(d) {
+        function onTreeWeightClick(d) {
             pdName = d.name;
             pdData = data;
             pdWeight = d.weight;
@@ -536,7 +536,7 @@
                     return (d.weight * 100).toFixed(1) + '%';
                 })
                 .on("click", function(d) {
-                    onTreeElementClick(d);
+                    onTreeWeightClick(d);
                 });
 
             // Transition nodes to their new position.

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -230,7 +230,7 @@
                     },
                     function() {
                     }).done(function() {
-                        tempProjectDef.push(projectDefStg);
+                        tempProjectDef.push(JSON.parse(projectDefStg));
                         $('#saveStateDialog').dialog('close');
                         $('#saveState-spinner').hide();
                         $('#saveBtn').prop('disabled', true);

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -45,6 +45,7 @@
     ////////////////////////////////////////////
 
     function loadPD(selectedPDef) {
+        // Rebuild the d3 tree, based on the given project definition
 
         // default tab window size
         var winH = 600;
@@ -636,7 +637,7 @@
             $('#projectDefWeight-spinner').remove();
         }
         $('#projectDef-spinner').hide();
-    } //end d3 tree
+    } //end loadPD
 
     $('#submitPD').click(function () {
         $('#submitPD').attr('disabled',true);
@@ -661,6 +662,8 @@
                 return value;
             });
 
+            // Temporarily disable the project definition selector
+            $('#pdSelection').prop("disabled", true);
             // Hit the API endpoint and grab the very very latest version of the PD object
             $.post( "../svir/add_project_definition", {
                 layer_name: selectedLayer,
@@ -685,6 +688,8 @@
                     $('#ajaxErrorDialog').dialog('open');
                     $('#submitPD').attr('disabled',true);
                     $('#saveState-spinner').hide();
+                }).always(function() {
+                    $('#pdSelection').prop("disabled", false);
             });
         }
     });


### PR DESCRIPTION
Final steps to fix https://github.com/gem/oq-platform/issues/540

The issue was partially fixed by https://github.com/gem/oq-platform/pull/541. After cleaning the project definition in order to avoid a recursion issue, we also had to re-parse it before adding it to the list of available project definitions.

I've also solved an annoying issue that was due to the fact that the handler for the submission of a new project definition was re-defined and triggered every time the `loadPD` function was called, instead of defining it separately and calling it only when the `submitPD` button is triggered. Extracting that function, the events work in the right order and we don't need anymore those ugly workarounds (timeouts, etc) that only partially solved the effects of this misbehavior. One of the removed timeouts was 3 seconds, which made the application slow even for small projects.