### PR TITLE
Tests timeouts fix

### DIFF
--- a/openquakeplatform/openquakeplatform/test/oqplatform.py
+++ b/openquakeplatform/openquakeplatform/test/oqplatform.py
@@ -42,10 +42,10 @@ class Platform(object):
         if not self.email:
             self.email = pla_email
 
-        time.sleep(5)
+        # time.sleep(5)
         self.driver.maximize_window()
         self.main_window = None
-        time.sleep(5)
+        # time.sleep(5)
         while not self.main_window:
             self.main_window = self.current_window_handle()
 

--- a/openquakeplatform/openquakeplatform/test/oqplatform.py
+++ b/openquakeplatform/openquakeplatform/test/oqplatform.py
@@ -42,11 +42,14 @@ class Platform(object):
         if not self.email:
             self.email = pla_email
 
+        time.sleep(5)
         self.driver.maximize_window()
         self.main_window = None
+        time.sleep(5)
         while not self.main_window:
             self.main_window = self.current_window_handle()
 
+        time.sleep(5)
         if self.homepage_login():
             self.is_logged = True
         time.sleep(3)

--- a/openquakeplatform/openquakeplatform/test/oqplatform.py
+++ b/openquakeplatform/openquakeplatform/test/oqplatform.py
@@ -278,7 +278,7 @@ class Platform(object):
     def get(self, url):
         self.driver.get(self.basepath + url)
 
-    def xpath_finduniq(self, xpath_str, times=1, postfind=0.2):
+    def xpath_finduniq(self, xpath_str, times=50, postfind=0.1):
         for t in range(0, times):
             field = self.driver.find_elements(By.XPATH, xpath_str)
             if len(field) > 0:

--- a/openquakeplatform/openquakeplatform/test/oqplatform.py
+++ b/openquakeplatform/openquakeplatform/test/oqplatform.py
@@ -42,17 +42,15 @@ class Platform(object):
         if not self.email:
             self.email = pla_email
 
-        # time.sleep(5)
         self.driver.maximize_window()
         self.main_window = None
-        # time.sleep(5)
         while not self.main_window:
             self.main_window = self.current_window_handle()
 
         time.sleep(5)
         if self.homepage_login():
             self.is_logged = True
-        time.sleep(3)
+        time.sleep(1)
 
     @staticmethod
     def driver_create(name, debugger):

--- a/openquakeplatform/openquakeplatform/test/vulnerability_test.py
+++ b/openquakeplatform/openquakeplatform/test/vulnerability_test.py
@@ -68,7 +68,7 @@ class VulnerabilityTest(unittest.TestCase):
         new_func_btn = plb.xpath_finduniq(
             "//li[@class='vuln_menu']/form[@action='/admin/vulnerability/"
             "generalinformation/add/']/button[@type='submit' and "
-            "@value='New function']", 50, 0.1)
+            "@value='New function']")
 
         new_func_btn.click()
         plb.wait_new_page(new_func_btn,
@@ -83,7 +83,7 @@ class VulnerabilityTest(unittest.TestCase):
 
         # taxtweb popup
         plb.select_window_by_name("TaxT")
-        samedirect = plb.xpath_finduniq("//input[@id='DirectionCB']", 50, 0.1)
+        samedirect = plb.xpath_finduniq("//input[@id='DirectionCB']")
         samedirect.click()
 
         dir_y = plb.xpath_finduniq("//li[@id='sub1tab_id-2']")
@@ -98,22 +98,20 @@ class VulnerabilityTest(unittest.TestCase):
         mat_prop_y = plb.xpath_finduniq("//select[@id='MaterialCB32']")
         plb.select_item_set(mat_prop_y, "Riveted connections")
 
-        popform = plb.xpath_finduniq("//li[@id='id_populate_form']", 5, 2)
+        popform = plb.xpath_finduniq("//li[@id='id_populate_form']")
         popform.click()
 
         # close popup and return to main window
         plb.windows_reset()
 
-        taxt_view = plb.xpath_finduniq("//input[@id='id_taxonomy_gem_view']",
-                                       5, 1)
+        taxt_view = plb.xpath_finduniq("//input[@id='id_taxonomy_gem_view']")
         self.assertEqual(taxt_view.get_attribute('value'),
                          u'DX/CU+CIP/DY/S+SR+RIV')
 
         outtype = plb.xpath_finduniq("//select[@id='OutTypeCB']")
         plb.select_item_set(outtype, "Full")
 
-        taxt_view = plb.xpath_finduniq("//input[@id='id_taxonomy_gem_view']",
-                                       5, 1)
+        taxt_view = plb.xpath_finduniq("//input[@id='id_taxonomy_gem_view']")
         self.assertEqual(taxt_view.get_attribute('value'),
                          u'DX+D99/CU+CIP/L99/DY+D99/S+SR+RIV/L99/H99/Y99/OC99/'
                          'BP99/PLF99/IR99/EW99/RSH99+RMT99+R99+RWC99/'

--- a/openquakeplatform/openquakeplatform/test/vulnerability_test.py
+++ b/openquakeplatform/openquakeplatform/test/vulnerability_test.py
@@ -62,12 +62,12 @@ class VulnerabilityTest(unittest.TestCase):
     def taxonomy_test(self):
         pla.user_add('one', 'one', 'one@example.com')
         plb = pla.platform_create(user='one', passwd='one')
-        time.sleep(5)
+        # time.sleep(5)
         plb.init()
 
-        time.sleep(5)
+        # time.sleep(5)
         plb.get('/vulnerability/list')
-        time.sleep(5)
+        # time.sleep(5)
 
         new_func_btn = plb.xpath_finduniq(
             "//li[@class='vuln_menu']/form[@action='/admin/vulnerability/"

--- a/openquakeplatform/openquakeplatform/test/vulnerability_test.py
+++ b/openquakeplatform/openquakeplatform/test/vulnerability_test.py
@@ -62,12 +62,9 @@ class VulnerabilityTest(unittest.TestCase):
     def taxonomy_test(self):
         pla.user_add('one', 'one', 'one@example.com')
         plb = pla.platform_create(user='one', passwd='one')
-        time.sleep(5)
         plb.init()
-
-        time.sleep(5)
+        time.sleep(3)
         plb.get('/vulnerability/list')
-        time.sleep(5)
 
         new_func_btn = plb.xpath_finduniq(
             "//li[@class='vuln_menu']/form[@action='/admin/vulnerability/"

--- a/openquakeplatform/openquakeplatform/test/vulnerability_test.py
+++ b/openquakeplatform/openquakeplatform/test/vulnerability_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import unittest
+import time
 
 from openquakeplatform.test import pla
 
@@ -61,9 +62,12 @@ class VulnerabilityTest(unittest.TestCase):
     def taxonomy_test(self):
         pla.user_add('one', 'one', 'one@example.com')
         plb = pla.platform_create(user='one', passwd='one')
+        time.sleep(5)
         plb.init()
 
+        time.sleep(5)
         plb.get('/vulnerability/list')
+        time.sleep(5)
 
         new_func_btn = plb.xpath_finduniq(
             "//li[@class='vuln_menu']/form[@action='/admin/vulnerability/"

--- a/openquakeplatform/openquakeplatform/test/vulnerability_test.py
+++ b/openquakeplatform/openquakeplatform/test/vulnerability_test.py
@@ -62,9 +62,12 @@ class VulnerabilityTest(unittest.TestCase):
     def taxonomy_test(self):
         pla.user_add('one', 'one', 'one@example.com')
         plb = pla.platform_create(user='one', passwd='one')
+        time.sleep(5)
         plb.init()
-        time.sleep(3)
+
+        time.sleep(5)
         plb.get('/vulnerability/list')
+        time.sleep(5)
 
         new_func_btn = plb.xpath_finduniq(
             "//li[@class='vuln_menu']/form[@action='/admin/vulnerability/"

--- a/openquakeplatform/openquakeplatform/test/vulnerability_test.py
+++ b/openquakeplatform/openquakeplatform/test/vulnerability_test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import unittest
-import time
 
 from openquakeplatform.test import pla
 
@@ -62,12 +61,9 @@ class VulnerabilityTest(unittest.TestCase):
     def taxonomy_test(self):
         pla.user_add('one', 'one', 'one@example.com')
         plb = pla.platform_create(user='one', passwd='one')
-        # time.sleep(5)
         plb.init()
 
-        # time.sleep(5)
         plb.get('/vulnerability/list')
-        # time.sleep(5)
 
         new_func_btn = plb.xpath_finduniq(
             "//li[@class='vuln_menu']/form[@action='/admin/vulnerability/"

--- a/openquakeplatform/openquakeplatform/test/vulnerability_test.py
+++ b/openquakeplatform/openquakeplatform/test/vulnerability_test.py
@@ -68,7 +68,7 @@ class VulnerabilityTest(unittest.TestCase):
         new_func_btn = plb.xpath_finduniq(
             "//li[@class='vuln_menu']/form[@action='/admin/vulnerability/"
             "generalinformation/add/']/button[@type='submit' and "
-            "@value='New function']")
+            "@value='New function']", 300, 1)
 
         new_func_btn.click()
         plb.wait_new_page(new_func_btn,

--- a/verifier.sh
+++ b/verifier.sh
@@ -120,6 +120,7 @@ copy_prod () {
 sig_hand () {
     trap ERR
     echo "signal trapped"
+    sleep 1000000 || true
     if [ "$lxc_name" != "" ]; then
         set +e
         ssh -t  $lxc_ip "cd ~/$GEM_GIT_PACKAGE; . platform-env/bin/activate ; cd openquakeplatform ; sleep 5 ; fab stop"

--- a/verifier.sh
+++ b/verifier.sh
@@ -469,6 +469,7 @@ _prodtest_innervm_run () {
     ssh -t  $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG
 rem_sig_hand() {
     trap ERR
+    sleep 1000000 || true
     echo 'signal trapped'
 }
 trap rem_sig_hand ERR

--- a/verifier.sh
+++ b/verifier.sh
@@ -120,7 +120,6 @@ copy_prod () {
 sig_hand () {
     trap ERR
     echo "signal trapped"
-    sleep 1000000 || true
     if [ "$lxc_name" != "" ]; then
         set +e
         ssh -t  $lxc_ip "cd ~/$GEM_GIT_PACKAGE; . platform-env/bin/activate ; cd openquakeplatform ; sleep 5 ; fab stop"
@@ -469,7 +468,6 @@ _prodtest_innervm_run () {
     ssh -t  $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG
 rem_sig_hand() {
     trap ERR
-    sleep 1000000 || true
     echo 'signal trapped'
 }
 trap rem_sig_hand ERR


### PR DESCRIPTION
Seems that a transient inconsistency in selenium is reflected in our tests broken them.
Added a delay between 2 critical operation is a good workaround.
Test are running here: https://ci.openquake.org/job/zzdevel_oq-platform/
and we scheduled a bunch of new jobs instances to be sure the problem is constantly solved.