### PR TITLE
IRV - Use separate widgets (instead of tabs), to display charts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,9 @@
   * irv: let the d3 tree layout look like in the QGIS IRMT plugin
   * irv: handle case in which a zone with no available data is clicked on the map
   * irv: when switching project definition, restyle the map accordingly
+  * irv: display charts in separate widgets instead of tabs
+  * irv: fix displaying the 'median' text when moving the mouse over a median line
+  * irv: enable zooming/panning for all d3 charts
 
 python-oq-platform (1.3.1)
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/css/irv_legend.css
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/css/irv_legend.css
@@ -7,10 +7,12 @@
 
 #mapInfo {
     position: fixed;
+    margin-top: 40px;
     right: 20px;
     padding: 10px 10px 15px;
     background-color: whitesmoke;
     border-radius: 15px;
+    visibility: hidden;
 }
 
 .my-legend .legend-title {

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1,4 +1,4 @@
-// TODO: Re-enable Show Composite Indicator Chart when a different project definition is selected
+// FIXME: Enable selecting a different theme in the Composite Indicator Chart
 /*
    Copyright (c) 2015, GEM Foundation.
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1672,6 +1672,9 @@ function loadProject() {
     setWidgetsToDefault();
     $('#thematic-map-selection').show();
     attributeInfoRequest(selectedLayer);
+    if (!$('#project-def-widget').is(':visible')) {
+        $('#toggleProjDefWidgetBtn').click();
+    }
 }
 
 function attributeInfoRequest(selectedLayer) {

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1,4 +1,3 @@
-// FIXME: Enable selecting a different theme in the Composite Indicator Chart
 /*
    Copyright (c) 2015, GEM Foundation.
 
@@ -1468,7 +1467,7 @@ var startApp = function() {
         widget.draggable({
             stack: "div",  // put on top of the others when dragging
             distance: 0,   // do it even if it's not actually moved
-            cancel: "#project-def"
+            cancel: "#project-def, #primary-tab, #cat-chart, #iri-chart"
         });
         widget.css({
             'display': 'none',

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -20,6 +20,10 @@ $(document).ready(function() {
     $('.alert-unscaled-data').hide();
     $('#absoluteSpinner').hide();
     $('#loadProjectBtn').show();
+    $('#toggleCompIndWidgetBtn').show();
+    $('#toggleSviThemeWidgetBtn').show();
+    $('#toggleIriChartWidgetBtn').show();
+    $('#toggleProjDefWidgetBtn').show();
 });
 
 var layerAttributes;
@@ -47,11 +51,6 @@ var regions = [];
 var baseMapUrl = new L.TileLayer('http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png');
 var app = new OQLeaflet.OQLeafletApp(baseMapUrl);
 var indicatorChildrenKey = [];
-
-$(document).ready(function() {
-    $('#cover').remove();
-    $('.alert-unscaled-data').hide();
-});
 
 function setWidgetsToDefault(){
     $('#pdSelection').empty();

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1,3 +1,4 @@
+// TODO: let all widgets overlap the others when selected
 /*
    Copyright (c) 2015, GEM Foundation.
 
@@ -67,11 +68,6 @@ var indicatorChildrenKey = [];
 function setWidgetsToDefault(){
     $('#pdSelection').empty();
     // set tabs back default
-    // FIXME: all widgets will have only 1 tab; handle things accordingly
-    $(widgetsAndButtons.iri.widget).tabs("enable", 2);
-    $(widgetsAndButtons.svi.widget).tabs("enable", 3);
-
-    $(widgetsAndButtons.projDef.widget).tabs('option', 'active', 0);
     $('#projectDef-spinner').text('Loading ...');
     $('#projectDef-spinner').append('<img id="download-button-spinner" src="/static/img/ajax-loader.gif" />');
     $('#projectDef-spinner').show();
@@ -794,8 +790,8 @@ function processIndicators(layerAttributes, projectDef) {
         SVI.plotElement = "SVI"; // Label within the object
         iriPcpData.push(SVI);
     } else {
-        // Disable the primary tab.
-        $(widgetsAndButtons.svi.widget).tabs("disable", 3);
+        disableWidget(widgetsAndButtons.svi);
+        disableWidget(widgetsAndButtons.indicators);
     }
 
     if (riskIndicators !== undefined) {
@@ -832,10 +828,6 @@ function scale(IndicatorObj) {
         if (tempMax == tempMin) {
             scaledValues = [1];
             // Disable the chart tabs
-            // $("#project-def-widget").tabs("disable", 1);
-            // $("#iri-chart-widget").tabs("disable", 2);
-            // $("#cat-chart-widget").tabs("disable", 3);
-            // FIXME: check what actually needs to be disabled
             $.each(['indicators', 'svi', 'iri'], function(i, widgetName) {
                 disableWidget(widgetsAndButtons[widgetName]);
             });

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1473,7 +1473,7 @@ var startApp = function() {
             'display': 'none',
             'width': '700px',
             'height': '600px',
-            'overflow': 'auto',
+            'overflow': 'hidden',
             'position': 'fixed',
             'left': (10 + i * 40) + 'px',
             'top': (110 + i * 40) + 'px'

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1557,13 +1557,16 @@ var startApp = function() {
     function toggleWidget(widgetAndBtn) {
         // toggle widget and change text on the corresponding button
         var btnText = $(widgetAndBtn.button).html();
+        // If the widget is visible, the button text is 'Hide Widgetname'
+        // Otherwise it is 'Show Widgetname'
+        // Let's change the button text before toggling the widget
         if (btnText.indexOf('Hide ') >= 0) {  // Change Hide -> Show
             btnText = 'Show ' + btnText.slice(5);
         } else {                              // Change Show -> Hide
             btnText = 'Hide ' + btnText.slice(5);
         }
-        $(widgetAndBtn.widget).toggle();
         $(widgetAndBtn.button).html(btnText);
+        $(widgetAndBtn.widget).toggle();
     }
 
     $.each(widgetsAndButtons, function(key, widgetAndBtn) {

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1162,6 +1162,7 @@ function mapboxGlLayerCreation() {
         map.featuresAt(e.point, { radius : 6}, function(err, features) {
             if (err) throw err;
             $('#mapInfo').empty();
+            $('#mapInfo').css({'visibility': 'visible'});
             if (typeof features[0] === 'undefined') {
                 $('#mapInfo').append('No data available');
             } else {

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -20,10 +20,6 @@ $(document).ready(function() {
     $('.alert-unscaled-data').hide();
     $('#absoluteSpinner').hide();
     $('#loadProjectBtn').show();
-    $('#toggleCompIndWidgetBtn').show();
-    $('#toggleSviThemeWidgetBtn').show();
-    $('#toggleIriChartWidgetBtn').show();
-    $('#toggleProjDefWidgetBtn').show();
 });
 
 var layerAttributes;
@@ -1477,16 +1473,16 @@ var startApp = function() {
         '<button id="loadProjectdialogBtn" type="button" class="btn btn-blue">Load Project</button>'
     );
     $('#map-tools').append(
-        '<button id="toggleCompIndWidgetBtn" type="button" class="btn btn-blue">Show Composite Indicator Chart</button>'
+        '<button id="toggleCompIndWidgetBtn" type="button" class="btn btn-blue" disabled>Show Composite Indicator Chart</button>'
     );
     $('#map-tools').append(
-        '<button id="toggleSviThemeWidgetBtn" type="button" class="btn btn-blue">Show SVI Theme Chart</button>'
+        '<button id="toggleSviThemeWidgetBtn" type="button" class="btn btn-blue" disabled>Show SVI Theme Chart</button>'
     );
     $('#map-tools').append(
-        '<button id="toggleIriChartWidgetBtn" type="button" class="btn btn-blue">Show IRI Chart Widget</button>'
+        '<button id="toggleIriChartWidgetBtn" type="button" class="btn btn-blue" disabled>Show IRI Chart Widget</button>'
     );
     $('#map-tools').append(
-        '<button id="toggleProjDefWidgetBtn" type="button" class="btn btn-blue">Show Project Definition</button>'
+        '<button id="toggleProjDefWidgetBtn" type="button" class="btn btn-blue" disabled>Show Project Definition</button>'
     );
 
 
@@ -1672,6 +1668,10 @@ function loadProject() {
     setWidgetsToDefault();
     $('#thematic-map-selection').show();
     attributeInfoRequest(selectedLayer);
+    $('#toggleProjDefWidgetBtn').prop('disabled', false);
+    $('#toggleIriChartWidgetBtn').prop('disabled', false);
+    $('#toggleSviThemeWidgetBtn').prop('disabled', false);
+    $('#toggleCompIndWidgetBtn').prop('disabled', false);
     if (!$('#project-def-widget').is(':visible')) {
         $('#toggleProjDefWidgetBtn').click();
     }

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -56,6 +56,7 @@ $(document).ready(function() {
 function setWidgetsToDefault(){
     $('#pdSelection').empty();
     // set tabs back default
+    // FIXME: all widgets will have only 1 tab; handle things accordingly
     $("#iri-chart-widget").tabs("enable", 2);
     $("#cat-chart-widget").tabs("enable", 3);
 
@@ -1276,7 +1277,6 @@ function thematicMapCreation() {
 }
 
 function whenProjDefSelected() {
-    $('#pdSelection').prop("disabled", true);
     $('#projectDef-spinner').show();
     var pdSelection = $('#pdSelection').val();
     for (var i = 0; i < tempProjectDef.length; i++) {
@@ -1289,7 +1289,6 @@ function whenProjDefSelected() {
             processIndicators(layerAttributes, sessionProjectDef);
         }
     }
-    $('#pdSelection').prop("disabled", false);
 }
 
 function getGeoServerLayers() {
@@ -1438,9 +1437,12 @@ var startApp = function() {
       });
 
       $(widget).draggable({
+          stack: "div",  // put on top of the others when dragging
+          distance: 0,  // do it even if it's not actually moved
           cancel: "#project-def"
       });
       $(widget).css({
+          'display': 'none',
           'width': '700px',
           'height': '600px',
           'overflow': 'auto',
@@ -1475,6 +1477,19 @@ var startApp = function() {
     $('#map-tools').append(
         '<button id="loadProjectdialogBtn" type="button" class="btn btn-blue">Load Project</button>'
     );
+    $('#map-tools').append(
+        '<button id="toggleCompIndWidgetBtn" type="button" class="btn btn-blue">Show Composite Indicator Chart</button>'
+    );
+    $('#map-tools').append(
+        '<button id="toggleSviThemeWidgetBtn" type="button" class="btn btn-blue">Show SVI Theme Chart</button>'
+    );
+    $('#map-tools').append(
+        '<button id="toggleIriChartWidgetBtn" type="button" class="btn btn-blue">Show IRI Chart Widget</button>'
+    );
+    $('#map-tools').append(
+        '<button id="toggleProjDefWidgetBtn" type="button" class="btn btn-blue">Show Project Definition</button>'
+    );
+
 
     if (webGl === false) {
         $('#map-tools').append(
@@ -1513,6 +1528,36 @@ var startApp = function() {
     $('#loadProjectdialogBtn').click(function() {
         getGeoServerLayers();
         $('#loadProjectDialog').dialog('open');
+    });
+
+    function toggleWidget(widget, btn) {
+        // toggle widget and change text on the corresponding button
+        var widgetIsVisible = widget.is(':visible');
+        var btnText = btn.html();
+        if (btnText.indexOf('Hide ') >= 0) {  // Change Hide -> Show
+            btnText = 'Show ' + btnText.slice(5);
+        } else {  // Change Show -> Hide
+            btnText = 'Hide ' + btnText.slice(5);
+        }
+        if (widgetIsVisible) {
+            widget.hide();
+        } else {
+            widget.show();
+        }
+        btn.html(btnText);
+    }
+
+    $('#toggleProjDefWidgetBtn').click(function() {
+        toggleWidget($('#project-def-widget'), $('#toggleProjDefWidgetBtn'));
+    });
+    $('#toggleIriChartWidgetBtn').click(function() {
+        toggleWidget($('#iri-chart-widget'), $('#toggleIriChartWidgetBtn'));
+    });
+    $('#toggleSviThemeWidgetBtn').click(function() {
+        toggleWidget($('#cat-chart-widget'), $('#toggleSviThemeWidgetBtn'));
+    });
+    $('#toggleCompIndWidgetBtn').click(function() {
+        toggleWidget($('#primary-tab-widget'), $('#toggleCompIndWidgetBtn'));
     });
 
     // TODO check these are all needed
@@ -1577,6 +1622,17 @@ var startApp = function() {
     $('#loadProjectdialogBtn').css({
         'position': 'fixed',
         'left': '50px'
+    });
+
+    $.each(['#toggleProjDefWidgetBtn',
+            '#toggleIriChartWidgetBtn',
+            '#toggleSviThemeWidgetBtn',
+            '#toggleCompIndWidgetBtn'], function(i, widget) {
+        $(widget).css({
+            'position': 'relative',
+            'float': 'right',
+            'margin-left': '2px'
+        });
     });
 
     $('#base-map-menu').css({

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -53,6 +53,24 @@ $(document).ready(function() {
     $('.alert-unscaled-data').hide();
 });
 
+function setWidgetsToDefault(){
+    $('#pdSelection').empty();
+    // set tabs back default
+    $("#iri-chart-widget").tabs("enable", 2);
+    $("#cat-chart-widget").tabs("enable", 3);
+
+    $('#project-def-widget').tabs('option', 'active', 0);
+    $('#projectDef-spinner').text('Loading ...');
+    $('#projectDef-spinner').append('<img id="download-button-spinner" src="/static/img/ajax-loader.gif" />');
+    $('#projectDef-spinner').show();
+    $('#iri-spinner').show();
+    $('#regionSelectionDialog').empty();
+    $('#projectDef-tree').empty();
+    $('#iri-chart').empty();
+    $('#cat-chart').empty();
+    $('#primary-chart').empty();
+}
+
 function scaleTheData() {
     // Create a list of primary indicators that need to be scaled
     // We are not scaling any of the IR indicators
@@ -765,7 +783,7 @@ function processIndicators(layerAttributes, projectDef) {
         iriPcpData.push(SVI);
     } else {
         // Disable the primary tab.
-        $("#themeTabs").tabs("disable", 3);
+        $("#cat-chart-widget").tabs("disable", 3);
     }
 
     if (riskIndicators !== undefined) {
@@ -793,9 +811,9 @@ function scale(IndicatorObj) {
         if (tempMax == tempMin) {
             scaledValues = [1];
             // Disable the chart tabs
-            $("#themeTabs").tabs("disable", 1);
-            $("#themeTabs").tabs("disable", 2);
-            $("#themeTabs").tabs("disable", 3);
+            $("#project-def-widget").tabs("disable", 1);
+            $("#iri-chart-widget").tabs("disable", 2);
+            $("#cat-chart-widget").tabs("disable", 3);
         } else {
             scaledValues.push( (ValueArray[j] - tempMin) / (tempMax - tempMin) );
         }
@@ -1258,6 +1276,7 @@ function thematicMapCreation() {
 }
 
 function whenProjDefSelected() {
+    $('#pdSelection').prop("disabled", true);
     $('#projectDef-spinner').show();
     var pdSelection = $('#pdSelection').val();
     for (var i = 0; i < tempProjectDef.length; i++) {
@@ -1270,6 +1289,7 @@ function whenProjDefSelected() {
             processIndicators(layerAttributes, sessionProjectDef);
         }
     }
+    $('#pdSelection').prop("disabled", false);
 }
 
 function getGeoServerLayers() {
@@ -1401,21 +1421,33 @@ var startApp = function() {
 
     webGl = webglDetect();
 
+    $.each(['#project-def-widget',
+            '#iri-chart-widget',
+            '#cat-chart-widget',
+            '#primary-tab-widget'], function(i, widget) {
+      // Theme tabs behavior
+      $(widget).resizable({
+          minHeight: 220,
+          minWidth: 220
+      });
 
-    // Theme tabs behavior
-    $('#themeTabs').resizable({
-        minHeight: 220,
-        minWidth: 220
-    });
+      $(widget).tabs({
+          collapsible: false,
+          selected: -1,
+          active: false,
+      });
 
-    $('#themeTabs').tabs({
-        collapsible: false,
-        selected: -1,
-        active: false,
-    });
-
-    $( "#themeTabs" ).draggable({
-        cancel: "#project-def"
+      $(widget).draggable({
+          cancel: "#project-def"
+      });
+      $(widget).css({
+          'width': '700px',
+          'height': '600px',
+          'overflow': 'auto',
+          'position': 'fixed',
+          'left': '10px',
+          'top': '110px'
+      });
     });
 
     $('#cover').remove();
@@ -1496,21 +1528,7 @@ var startApp = function() {
     });
 
     $('#loadProjectBtn').click(function() {
-        $('#pdSelection').empty();
-        // set tabs back default
-        $("#themeTabs").tabs("enable", 2);
-        $("#themeTabs").tabs("enable", 3);
-
-        $('#themeTabs').tabs('option', 'active', 0);
-        $('#projectDef-spinner').text('Loading ...');
-        $('#projectDef-spinner').append('<img id="download-button-spinner" src="/static/img/ajax-loader.gif" />');
-        $('#projectDef-spinner').show();
-        $('#iri-spinner').show();
-        $('#regionSelectionDialog').empty();
-        $('#projectDef-tree').empty();
-        $('#iri-chart').empty();
-        $('#cat-chart').empty();
-        $('#primary-chart').empty();
+        setWidgetsToDefault();
 
         // FIXME This will not work if the title contains '(' or ')'
         // Get the selected layer
@@ -1556,15 +1574,6 @@ var startApp = function() {
         'z-index': 6
     });
 
-    $('#themeTabs').css({
-        'width': '700px',
-        'height': '600px',
-        'overflow': 'hidden',
-        'position': 'fixed',
-        'left': '10px',
-        'top': '110px'
-    });
-
     $('#loadProjectdialogBtn').css({
         'position': 'fixed',
         'left': '50px'
@@ -1605,23 +1614,8 @@ var startApp = function() {
 };
 
 function loadProject() {
-    $('#pdSelection').empty();
-    // set tabs to back default
-    $("#themeTabs").tabs("enable", 2);
-    $("#themeTabs").tabs("enable", 3);
-
-    $('#themeTabs').tabs('option', 'active', 0);
+    setWidgetsToDefault();
     $('#thematic-map-selection').show();
-    $('#projectDef-spinner').text('Loading ...');
-    $('#projectDef-spinner').append('<img id="download-button-spinner" src="/static/img/ajax-loader.gif" />');
-    $('#projectDef-spinner').show();
-    $('#iri-spinner').show();
-    $('#regionSelectionDialog').empty();
-    $('#projectDef-tree').empty();
-    $('#iri-chart').empty();
-    $('#cat-chart').empty();
-    $('#primary-chart').empty();
-
     attributeInfoRequest(selectedLayer);
 }
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1,4 +1,4 @@
-// TODO: let all widgets overlap the others when selected
+// TODO: Re-enable Show Composite Indicator Chart when a different project definition is selected
 /*
    Copyright (c) 2015, GEM Foundation.
 
@@ -1567,7 +1567,6 @@ var startApp = function() {
         $(widgetAndBtn.button).html(btnText);
     }
 
-    // FIXME: suspect inner definition of click
     $.each(widgetsAndButtons, function(key, widgetAndBtn) {
         $(widgetAndBtn.button).click(function() {
             toggleWidget(widgetAndBtn);
@@ -1624,6 +1623,11 @@ var startApp = function() {
         closeOnEscape: true
     });
 
+    $('#loadProjectDialog').draggable({
+        stack: "div",  // put on top of the others when dragging
+        distance: 0,   // do it even if it's not actually moved
+    });
+
     $('#map-tools').css({
         'padding': '6px',
         'position': 'absolute',
@@ -1638,7 +1642,6 @@ var startApp = function() {
         'left': '50px'
     });
 
-    // FIXME: for some reason, this is not styling the buttons
     $.each(widgetsAndButtons, function(key, widgetAndBtn) {
         $(widgetAndBtn.button).css({
             'position': 'relative',

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -15,17 +15,17 @@
       along with this program.  If not, see <https://www.gnu.org/licenses/agpl.html>.
 */
 var widgetsAndButtons = {
-    'projDef':    {'widget':     $('#project-def-widget'),
-                   'button':     $('#toggleProjDefWidgetBtn'),
+    'projDef':    {'widget':     '#project-def-widget',
+                   'button':     '#toggleProjDefWidgetBtn',
                    'buttonText': 'Show Project Definition'},
-    'iri':        {'widget':     $('#iri-chart-widget'),
-                   'button':     $('#toggleIriChartWidgetBtn'),
+    'iri':        {'widget':     '#iri-chart-widget',
+                   'button':     '#toggleIriChartWidgetBtn',
                    'buttonText': 'Show IRI Chart Widget'},
-    'svi':        {'widget':     $('#cat-chart-widget'),
-                   'button':     $('#toggleSviThemeWidgetBtn'),
+    'svi':        {'widget':     '#cat-chart-widget',
+                   'button':     '#toggleSviThemeWidgetBtn',
                    'buttonText': 'Show SVI Theme Chart'},
-    'indicators': {'widget':     $('#primary-tab-widget'),
-                   'button':     $('#toggleCompIndWidgetBtn'),
+    'indicators': {'widget':     '#primary-tab-widget',
+                   'button':     '#toggleCompIndWidgetBtn',
                    'buttonText': 'Show Composite Indicator Chart'}
 };
 
@@ -67,10 +67,10 @@ function setWidgetsToDefault(){
     $('#pdSelection').empty();
     // set tabs back default
     // FIXME: all widgets will have only 1 tab; handle things accordingly
-    widgetsAndButtons.iri.widget.tabs("enable", 2);
-    widgetsAndButtons.svi.widget.tabs("enable", 3);
+    $(widgetsAndButtons.iri.widget).tabs("enable", 2);
+    $(widgetsAndButtons.svi.widget).tabs("enable", 3);
 
-    widgetsAndButtons.projDef.widget.tabs('option', 'active', 0);
+    $(widgetsAndButtons.projDef.widget).tabs('option', 'active', 0);
     $('#projectDef-spinner').text('Loading ...');
     $('#projectDef-spinner').append('<img id="download-button-spinner" src="/static/img/ajax-loader.gif" />');
     $('#projectDef-spinner').show();
@@ -794,7 +794,7 @@ function processIndicators(layerAttributes, projectDef) {
         iriPcpData.push(SVI);
     } else {
         // Disable the primary tab.
-        widgetsAndButtons.svi.widget.tabs("disable", 3);
+        $(widgetsAndButtons.svi.widget).tabs("disable", 3);
     }
 
     if (riskIndicators !== undefined) {
@@ -809,11 +809,11 @@ function processIndicators(layerAttributes, projectDef) {
 
 function disableWidget(widgetAndBtn) {
     // if the widget is visible, click the button to toggle it
-    if (widgetAndBtn.widget.is(':visible')) {
-        widgetAndBtn.button.click();
+    if ($(widgetAndBtn.widget).is(':visible')) {
+        $(widgetAndBtn.button).click();
     }
     // in any case, disable the button that shows the widget
-    widgetAndBtn.button.prop('disabled', true);
+    $(widgetAndBtn.button).prop('disabled', true);
 }
 
 function scale(IndicatorObj) {
@@ -1446,7 +1446,7 @@ var startApp = function() {
     // using the list, otherwise we would lose the order
     $.each(['projDef', 'iri', 'svi', 'indicators'], function(i, widgetName) {
         // Theme tabs behavior
-        var widget = widgetsAndButtons[widgetName].widget;
+        var widget = $(widgetsAndButtons[widgetName].widget);
         widget.resizable({
             minHeight: 220,
             minWidth: 220
@@ -1502,7 +1502,7 @@ var startApp = function() {
     // Using the list in order to keep the order
     $.each(['indicators', 'svi', 'iri', 'projDef'], function(i, widgetName) {
         // slice(1) removes the heading # from the selector
-        var buttonId = widgetsAndButtons[widgetName].button.selector.slice(1);
+        var buttonId = widgetsAndButtons[widgetName].button.slice(1);
         var buttonText = widgetsAndButtons[widgetName].buttonText;
         $('#map-tools').append(
             '<button id="' + buttonId + '" type="button" class="btn btn-blue" disabled>' + buttonText + '</button>'
@@ -1550,19 +1550,19 @@ var startApp = function() {
 
     function toggleWidget(widgetAndBtn) {
         // toggle widget and change text on the corresponding button
-        var btnText = widgetAndBtn.button.html();
+        var btnText = $(widgetAndBtn.button).html();
         if (btnText.indexOf('Hide ') >= 0) {  // Change Hide -> Show
             btnText = 'Show ' + btnText.slice(5);
         } else {                              // Change Show -> Hide
             btnText = 'Hide ' + btnText.slice(5);
         }
-        widgetAndBtn.widget.toggle();
-        widgetAndBtn.button.html(btnText);
+        $(widgetAndBtn.widget).toggle();
+        $(widgetAndBtn.button).html(btnText);
     }
 
     // FIXME: suspect inner definition of click
     $.each(widgetsAndButtons, function(key, widgetAndBtn) {
-        widgetAndBtn.button.click(function() {
+        $(widgetAndBtn.button).click(function() {
             toggleWidget(widgetAndBtn);
         });
     });
@@ -1633,7 +1633,7 @@ var startApp = function() {
 
     // FIXME: for some reason, this is not styling the buttons
     $.each(widgetsAndButtons, function(key, widgetAndBtn) {
-        widgetAndBtn.button.css({
+        $(widgetAndBtn.button).css({
             'position': 'relative',
             'float': 'right',
             'margin-left': '2px'
@@ -1680,11 +1680,11 @@ function loadProject() {
     attributeInfoRequest(selectedLayer);
     $.each(widgetsAndButtons, function(key, widgetAndBtn) {
         // just enable buttons without opening widgets
-        widgetAndBtn.button.prop('disabled', false);
+        $(widgetAndBtn.button).prop('disabled', false);
     });
     // open the project definition widget if it's not already open
-    if (!widgetsAndButtons.projDef.widget.is(':visible')) {
-        widgetsAndButtons.projDef.button.click();
+    if (!$(widgetsAndButtons.projDef.widget).is(':visible')) {
+        $(widgetsAndButtons.projDef.button).click();
     }
 }
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -14,6 +14,21 @@
       You should have received a copy of the GNU Affero General Public License
       along with this program.  If not, see <https://www.gnu.org/licenses/agpl.html>.
 */
+var widgetsAndButtons = {
+    'projDef':    {'widget':     $('#project-def-widget'),
+                   'button':     $('#toggleProjDefWidgetBtn'),
+                   'buttonText': 'Show Project Definition'},
+    'iri':        {'widget':     $('#iri-chart-widget'),
+                   'button':     $('#toggleIriChartWidgetBtn'),
+                   'buttonText': 'Show IRI Chart Widget'},
+    'svi':        {'widget':     $('#cat-chart-widget'),
+                   'button':     $('#toggleSviThemeWidgetBtn'),
+                   'buttonText': 'Show SVI Theme Chart'},
+    'indicators': {'widget':     $('#primary-tab-widget'),
+                   'button':     $('#toggleCompIndWidgetBtn'),
+                   'buttonText': 'Show Composite Indicator Chart'}
+};
+
 
 $(document).ready(function() {
     $('#cover').remove();
@@ -52,10 +67,10 @@ function setWidgetsToDefault(){
     $('#pdSelection').empty();
     // set tabs back default
     // FIXME: all widgets will have only 1 tab; handle things accordingly
-    $("#iri-chart-widget").tabs("enable", 2);
-    $("#cat-chart-widget").tabs("enable", 3);
+    widgetsAndButtons.iri.widget.tabs("enable", 2);
+    widgetsAndButtons.svi.widget.tabs("enable", 3);
 
-    $('#project-def-widget').tabs('option', 'active', 0);
+    widgetsAndButtons.projDef.widget.tabs('option', 'active', 0);
     $('#projectDef-spinner').text('Loading ...');
     $('#projectDef-spinner').append('<img id="download-button-spinner" src="/static/img/ajax-loader.gif" />');
     $('#projectDef-spinner').show();
@@ -779,7 +794,7 @@ function processIndicators(layerAttributes, projectDef) {
         iriPcpData.push(SVI);
     } else {
         // Disable the primary tab.
-        $("#cat-chart-widget").tabs("disable", 3);
+        widgetsAndButtons.svi.widget.tabs("disable", 3);
     }
 
     if (riskIndicators !== undefined) {
@@ -791,6 +806,15 @@ function processIndicators(layerAttributes, projectDef) {
 
 
 } // End processIndicators
+
+function disableWidget(widgetAndBtn) {
+    // if the widget is visible, click the button to toggle it
+    if (widgetAndBtn.widget.is(':visible')) {
+        widgetAndBtn.button.click();
+    }
+    // in any case, disable the button that shows the widget
+    widgetAndBtn.button.prop('disabled', true);
+}
 
 function scale(IndicatorObj) {
     var ValueArray = [];
@@ -807,9 +831,13 @@ function scale(IndicatorObj) {
         if (tempMax == tempMin) {
             scaledValues = [1];
             // Disable the chart tabs
-            $("#project-def-widget").tabs("disable", 1);
-            $("#iri-chart-widget").tabs("disable", 2);
-            $("#cat-chart-widget").tabs("disable", 3);
+            // $("#project-def-widget").tabs("disable", 1);
+            // $("#iri-chart-widget").tabs("disable", 2);
+            // $("#cat-chart-widget").tabs("disable", 3);
+            // FIXME: check what actually needs to be disabled
+            $.each(['indicators', 'svi', 'iri'], function(i, widgetName) {
+                disableWidget(widgetsAndButtons[widgetName]);
+            });
         } else {
             scaledValues.push( (ValueArray[j] - tempMin) / (tempMax - tempMin) );
         }
@@ -1415,36 +1443,35 @@ var startApp = function() {
 
     webGl = webglDetect();
 
-    $.each(['#project-def-widget',
-            '#iri-chart-widget',
-            '#cat-chart-widget',
-            '#primary-tab-widget'], function(i, widget) {
-      // Theme tabs behavior
-      $(widget).resizable({
-          minHeight: 220,
-          minWidth: 220
-      });
+    // using the list, otherwise we would lose the order
+    $.each(['projDef', 'iri', 'svi', 'indicators'], function(i, widgetName) {
+        // Theme tabs behavior
+        var widget = widgetsAndButtons[widgetName].widget;
+        widget.resizable({
+            minHeight: 220,
+            minWidth: 220
+        });
 
-      $(widget).tabs({
-          collapsible: false,
-          selected: -1,
-          active: false,
-      });
+        widget.tabs({
+            collapsible: false,
+            selected: -1,
+            active: false,
+        });
 
-      $(widget).draggable({
-          stack: "div",  // put on top of the others when dragging
-          distance: 0,  // do it even if it's not actually moved
-          cancel: "#project-def"
-      });
-      $(widget).css({
-          'display': 'none',
-          'width': '700px',
-          'height': '600px',
-          'overflow': 'auto',
-          'position': 'fixed',
-          'left': (10 + i * 40) + 'px',
-          'top': (110 + i * 40) + 'px'
-      });
+        widget.draggable({
+            stack: "div",  // put on top of the others when dragging
+            distance: 0,   // do it even if it's not actually moved
+            cancel: "#project-def"
+        });
+        widget.css({
+            'display': 'none',
+            'width': '700px',
+            'height': '600px',
+            'overflow': 'auto',
+            'position': 'fixed',
+            'left': (10 + i * 40) + 'px',
+            'top': (110 + i * 40) + 'px'
+        });
     });
 
     $('#cover').remove();
@@ -1472,19 +1499,15 @@ var startApp = function() {
     $('#map-tools').append(
         '<button id="loadProjectdialogBtn" type="button" class="btn btn-blue">Load Project</button>'
     );
-    $('#map-tools').append(
-        '<button id="toggleCompIndWidgetBtn" type="button" class="btn btn-blue" disabled>Show Composite Indicator Chart</button>'
-    );
-    $('#map-tools').append(
-        '<button id="toggleSviThemeWidgetBtn" type="button" class="btn btn-blue" disabled>Show SVI Theme Chart</button>'
-    );
-    $('#map-tools').append(
-        '<button id="toggleIriChartWidgetBtn" type="button" class="btn btn-blue" disabled>Show IRI Chart Widget</button>'
-    );
-    $('#map-tools').append(
-        '<button id="toggleProjDefWidgetBtn" type="button" class="btn btn-blue" disabled>Show Project Definition</button>'
-    );
-
+    // Using the list in order to keep the order
+    $.each(['indicators', 'svi', 'iri', 'projDef'], function(i, widgetName) {
+        // slice(1) removes the heading # from the selector
+        var buttonId = widgetsAndButtons[widgetName].button.selector.slice(1);
+        var buttonText = widgetsAndButtons[widgetName].buttonText;
+        $('#map-tools').append(
+            '<button id="' + buttonId + '" type="button" class="btn btn-blue" disabled>' + buttonText + '</button>'
+        );
+    });
 
     if (webGl === false) {
         $('#map-tools').append(
@@ -1525,34 +1548,23 @@ var startApp = function() {
         $('#loadProjectDialog').dialog('open');
     });
 
-    function toggleWidget(widget, btn) {
+    function toggleWidget(widgetAndBtn) {
         // toggle widget and change text on the corresponding button
-        var widgetIsVisible = widget.is(':visible');
-        var btnText = btn.html();
+        var btnText = widgetAndBtn.button.html();
         if (btnText.indexOf('Hide ') >= 0) {  // Change Hide -> Show
             btnText = 'Show ' + btnText.slice(5);
-        } else {  // Change Show -> Hide
+        } else {                              // Change Show -> Hide
             btnText = 'Hide ' + btnText.slice(5);
         }
-        if (widgetIsVisible) {
-            widget.hide();
-        } else {
-            widget.show();
-        }
-        btn.html(btnText);
+        widgetAndBtn.widget.toggle();
+        widgetAndBtn.button.html(btnText);
     }
 
-    $('#toggleProjDefWidgetBtn').click(function() {
-        toggleWidget($('#project-def-widget'), $('#toggleProjDefWidgetBtn'));
-    });
-    $('#toggleIriChartWidgetBtn').click(function() {
-        toggleWidget($('#iri-chart-widget'), $('#toggleIriChartWidgetBtn'));
-    });
-    $('#toggleSviThemeWidgetBtn').click(function() {
-        toggleWidget($('#cat-chart-widget'), $('#toggleSviThemeWidgetBtn'));
-    });
-    $('#toggleCompIndWidgetBtn').click(function() {
-        toggleWidget($('#primary-tab-widget'), $('#toggleCompIndWidgetBtn'));
+    // FIXME: suspect inner definition of click
+    $.each(widgetsAndButtons, function(key, widgetAndBtn) {
+        widgetAndBtn.button.click(function() {
+            toggleWidget(widgetAndBtn);
+        });
     });
 
     // TODO check these are all needed
@@ -1619,11 +1631,9 @@ var startApp = function() {
         'left': '50px'
     });
 
-    $.each(['#toggleProjDefWidgetBtn',
-            '#toggleIriChartWidgetBtn',
-            '#toggleSviThemeWidgetBtn',
-            '#toggleCompIndWidgetBtn'], function(i, widget) {
-        $(widget).css({
+    // FIXME: for some reason, this is not styling the buttons
+    $.each(widgetsAndButtons, function(key, widgetAndBtn) {
+        widgetAndBtn.button.css({
             'position': 'relative',
             'float': 'right',
             'margin-left': '2px'
@@ -1668,12 +1678,13 @@ function loadProject() {
     setWidgetsToDefault();
     $('#thematic-map-selection').show();
     attributeInfoRequest(selectedLayer);
-    $('#toggleProjDefWidgetBtn').prop('disabled', false);
-    $('#toggleIriChartWidgetBtn').prop('disabled', false);
-    $('#toggleSviThemeWidgetBtn').prop('disabled', false);
-    $('#toggleCompIndWidgetBtn').prop('disabled', false);
-    if (!$('#project-def-widget').is(':visible')) {
-        $('#toggleProjDefWidgetBtn').click();
+    $.each(widgetsAndButtons, function(key, widgetAndBtn) {
+        // just enable buttons without opening widgets
+        widgetAndBtn.button.prop('disabled', false);
+    });
+    // open the project definition widget if it's not already open
+    if (!widgetsAndButtons.projDef.widget.is(':visible')) {
+        widgetsAndButtons.projDef.button.click();
     }
 }
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1442,8 +1442,8 @@ var startApp = function() {
           'height': '600px',
           'overflow': 'auto',
           'position': 'fixed',
-          'left': '10px',
-          'top': '110px'
+          'left': (10 + i * 40) + 'px',
+          'top': (110 + i * 40) + 'px'
       });
     });
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_IRI.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_IRI.js
@@ -69,10 +69,16 @@ function IRI_PCP_Chart(iriPcpData) {
         .scale(x);
 
     $("#iri-chart").empty();
+    $("#iri-chart").css({'height': '100%'});
 
     var svg = d3.select("#iri-chart").append("svg")
+        .attr("width", "100%")
+        .attr("height", "100%")
         .attr("viewBox", "-30 -20 " +winW+" " + (winH +20))
         .attr("id", "IRI-svg-element")
+        .call(d3.behavior.zoom().scaleExtent([0.1, 5]).on("zoom", function () {
+            svg.attr("transform", "translate(" + d3.event.translate + ")" + " scale(" + d3.event.scale + ")");
+        }))
         .append("svg:g")
         .attr("transform", "translate(" + m[3] + ",5)");
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_IRI.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_IRI.js
@@ -210,42 +210,51 @@ function IRI_PCP_Chart(iriPcpData) {
     //// Median line ////
     //////////////////////
 
-     // Build skeleton array
-     for (var t in iriPcpData[0]) {
-         sum[t] = 0;
-     }
+    // Build skeleton array
+    for (var t in iriPcpData[0]) {
+        sum[t] = 0;
+    }
 
-     // Sum all the paths
-     // Access the objects contained in the theme data array
-     for (var region_idx = 0; region_idx < iriPcpData.length; region_idx++) {
-        // iterate over the each
-         for (var elementName in iriPcpData[region_idx]) {
-            // This will sum all the values inside each theme object
-             sum[elementName] += iriPcpData[region_idx][elementName];
-         }
-     }
+    // Sum all the paths
+    // Access the objects contained in the theme data array
+    for (var region_idx = 0; region_idx < iriPcpData.length; region_idx++) {
+    // iterate over the each
+        for (var elementName in iriPcpData[region_idx]) {
+        // This will sum all the values inside each theme object
+            sum[elementName] += iriPcpData[region_idx][elementName];
+        }
+    }
 
-     // Get the mean
-     for (var f in sum) {
-         var thisSum = sum[f];
-         sumMean[f] = (thisSum / iriPcpData.length);
-     }
+    // Get the mean
+    for (var f in sum) {
+        var thisSum = sum[f];
+        sumMean[f] = (thisSum / iriPcpData.length);
+    }
 
-     sumMeanArray.push(sumMean);
+    sumMeanArray.push(sumMean);
 
-     // Plot the median line
-     meanPath = svg.append("g")
-         .attr("class", "PI-meanPath")
-         .selectAll("path")
-         .data(sumMeanArray)
-         .enter().append("path")
-         .attr("d", path)
-         .attr('id', function(d) { return d.region; })
-             .on('mouseover', function() {
-                 textTop.text('Median');
-             }).on('mouseout', function() {
-                 textTop.text('');
-             });
+    var textTop = svg.append('text')
+        .attr("class", "text90")
+        .style('font-size','30px')
+        .style('font-style', 'bold')
+        .text('');
+
+    // Plot the median line
+    meanPath = svg.append("g")
+        .attr("class", "PI-meanPath")
+        .selectAll("path")
+        .data(sumMeanArray)
+        .enter().append("path")
+        .attr("d", path)
+        .attr('id', function(d) { return d.region; })
+            .on('mouseover', function(d) {
+                textTop.attr('x', d.x);
+                textTop.attr('y', d.y);
+                textTop.attr('dy', '.35em');
+                textTop.text('Median');
+            }).on('mouseout', function() {
+                textTop.text('');
+            });
 
     // Handles a brush event, toggling the display of foreground lines.
     function brush() {

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_primary.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_primary.js
@@ -38,6 +38,9 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
             // continue
         }
     }
+    if (themesWithChildren) {
+        $(widgetsAndButtons.indicators.button).prop('disabled', false);
+    }
 
     $('#primary_indicator').empty();
     $('#primary_indicator').append('<option value="">Select a Theme</option>');

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_primary.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_primary.js
@@ -287,6 +287,12 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
 
         sumMeanArray.push(sumMean);
 
+        var textTop = svg.append('text')
+            .attr("class", "text90")
+            .style('font-size','30px')
+            .style('font-style', 'bold')
+            .text('');
+
         // Plot the median line
         meanPath = svg.append("g")
             .attr("class", "PI-meanPath")
@@ -295,7 +301,10 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
             .enter().append("path")
             .attr("d", path)
             .attr('id', function(d) { return d.region; })
-                .on('mouseover', function() {
+                .on('mouseover', function(d) {
+                    textTop.attr('x', d.x);
+                    textTop.attr('y', d.y);
+                    textTop.attr('dy', '.35em');
                     textTop.text('Median');
                 }).on('mouseout', function() {
                     textTop.text('');

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_primary.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_primary.js
@@ -99,6 +99,7 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
             }
         }
 
+        $('#primary-tab').css({'height': '100%'});
         $('#primary-tab').append('<div id="primary-chart"></div>');
 
 
@@ -144,10 +145,16 @@ function Primary_PCP_Chart(projectDef, layerAttributes, selectedRegion) {
             .scale(x);
 
         $("#primary-chart").empty();
+        $("#primary-chart").css({'height': '100%'});
 
         var svg = d3.select("#primary-chart").append("svg")
+            .attr("width", "100%")
+            .attr("height", "100%")
             .attr("viewBox", "-30 -20 " +winW+" " + (winH +20))
             .attr("id", "primary-svg-element")
+            .call(d3.behavior.zoom().scaleExtent([0.1, 5]).on("zoom", function () {
+                svg.attr("transform", "translate(" + d3.event.translate + ")" + " scale(" + d3.event.scale + ")");
+            }))
             .append("svg:g")
             .attr("transform", "translate(" + m[3] + ",5)");
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
@@ -65,9 +65,9 @@ function Theme_PCP_Chart(themeData) {
         }
     }
 
-    for (var i = 0; i < eachElementInThemeData.length; i++) {
-        if (!isNaN(parseFloat(eachElementInThemeData[i])) && isFinite(eachElementInThemeData[i])) {
-            eachValueInThemeData.push(eachElementInThemeData[i]);
+    for (var j = 0; j < eachElementInThemeData.length; j++) {
+        if (!isNaN(parseFloat(eachElementInThemeData[j])) && isFinite(eachElementInThemeData[j])) {
+            eachValueInThemeData.push(eachElementInThemeData[j]);
         }
     }
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
@@ -43,7 +43,7 @@ function Theme_PCP_Chart(themeData) {
         // Stop the function from continuing.
         return;
     } else {
-        widgetsAndButtons.svi.button.prop('disabled', false);
+        $(widgetsAndButtons.svi.button).prop('disabled', false);
     }
 
     var data = themeData;

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
@@ -85,10 +85,16 @@ function Theme_PCP_Chart(themeData) {
         foreground;
 
     $('#cat-chart').empty();
+    $("#cat-chart").css({'height': '100%'});
 
     var svg = d3.select('#cat-chart').append('svg')
+        .attr("width", "100%")
+        .attr("height", "100%")
         .attr("viewBox", "100 20 " +(winW -400)+" " +winH)
         .attr("id", "CI-svg-element")
+        .call(d3.behavior.zoom().scaleExtent([0.1, 5]).on("zoom", function () {
+            svg.attr("transform", "translate(" + d3.event.translate + ")" + " scale(" + d3.event.scale + ")");
+        }))
         .append('g')
         .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
@@ -39,10 +39,11 @@ function Theme_PCP_Chart(themeData) {
 
     if (themeCount <= 2) {
         // Disable the theme tab.
-        // FIXME: disable the whole widget instead
-        $("#iri-chart-widget").tabs("disable", 2);
+        disableWidget(widgetsAndButtons.svi);
         // Stop the function from continuing.
         return;
+    } else {
+        widgetsAndButtons.svi.button.prop('disabled', false);
     }
 
     var data = themeData;

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_PCP_theme.js
@@ -39,7 +39,8 @@ function Theme_PCP_Chart(themeData) {
 
     if (themeCount <= 2) {
         // Disable the theme tab.
-        $("#themeTabs").tabs("disable", 2);
+        // FIXME: disable the whole widget instead
+        $("#iri-chart-widget").tabs("disable", 2);
         // Stop the function from continuing.
         return;
     }

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -45,14 +45,13 @@
     ////////////////////////////////////////////
 
     function loadPD(selectedPDef) {
-        // Rebuild the d3 tree, based on the given project definition
 
         // default tab window size
         var winH = 600;
         var winW = 700;
 
         // detect tab window resize
-        $('#themeTabs').resize(function(event) {
+        $('#project-def-widget').resize(function(event) {
             winH = event.clientY;
             winW = event.clientX;
         });

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -45,6 +45,7 @@
     ////////////////////////////////////////////
 
     function loadPD(selectedPDef) {
+        // Rebuild the d3 tree, based on the given project definition
 
         // default tab window size
         var winH = 600;

--- a/openquakeplatform/openquakeplatform/irv/templates/irv/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/irv/templates/irv/irv_viewer.html
@@ -69,28 +69,40 @@ IRV - {{block.super}}
       <input type="button" id="loadProjectBtn" style="display:none" class="btn btn-blue" disabled="disabled" value="Load Selection">
   </div>
 
-  <!-- Theme tags-->
-  <div id="themeTabs">
+  <div id="project-def-widget">
     <ul>
-      <li id="1" ><a href="#project-def">Project Definition</a></li>
-      <li id="2"><a href="#iri-chart">IRI Chart</a></li>
-      <li id="3"><a href="#cat-chart">SVI Theme Chart</a></li>
-      <li id="4"><a href="#primary-tab">Composite Indicator Chart</a></li>
-
+      <li id="1"><a href="#project-def">Project Definition</a></li>
     </ul>
-
     <div id="project-def">
-      <button id="saveBtn" class="btn btn-blue">Save Project Definition</button>
-      <div id="tool-tip"></div>
-      <div id="projectDef-tree"></div>
-      <div id="projectDefDialog" title="Project Definition">
-        <div id="projectDef-spinner" ></div>
-      </div>
+        <button id="saveBtn" class="btn btn-blue">Save Project Definition</button>
+        <div id="tool-tip"></div>
+        <div id="projectDef-tree"></div>
+        <div id="projectDefDialog" title="Project Definition">
+          <div id="projectDef-spinner" ></div>
+        </div>
     </div>
+  </div>
+
+  <div id="iri-chart-widget">
+    <ul>
+      <li id="2"><a href="#iri-chart">IRI Chart</a></li>
+    </ul>
     <div id="iri-chart">
       <div id="iri-spinner" >Loading ...<img id="download-button-spinner" src="{{ STATIC_URL }}img/ajax-loader.gif" /></div>
     </div>
+  </div>
+
+  <div id="cat-chart-widget">
+    <ul>
+      <li id="3"><a href="#cat-chart">SVI Theme Chart</a></li>
+    </ul>
     <div id="cat-chart"></div>
+  </div>
+
+  <div id="primary-tab-widget">
+    <ul>
+      <li id="4"><a href="#primary-tab">Composite Indicator Chart</a></li>
+    </ul>
     <div id="primary-tab">
       <div id="mainContainer">
         <div class="alert-unscaled-data">
@@ -104,9 +116,8 @@ IRV - {{block.super}}
         </p>
       </div>
     </div>
-
-
   </div>
+
 </div>
 
 {% endblock middle %}


### PR DESCRIPTION
While working in the direction described by the title, I made a couple of improvements/fixes:

* moving the mouse over the median line, now the text 'median' is correctly displayed for all charts (before, it produced errors in some cases)
* I've added the zooming/panning functionality to all the charts, also removing the scrollbars to those widgets and fixing the layouts in order to let the charts fill the whole available space 

Tests are green: https://ci.openquake.org/job/zdevel_oq-platform/233/