### PR TITLE
taxtweb: add introduction link to building taxonomy

### DIFF
--- a/openquakeplatform/openquakeplatform/taxtweb/templates/taxtweb/incl_taxtweb_content.html
+++ b/openquakeplatform/openquakeplatform/taxtweb/templates/taxtweb/incl_taxtweb_content.html
@@ -1,7 +1,9 @@
 <div class="grand_parent">
     <ul class="tab">
-        {{ tab_content|safe }}<li id="id_help_form" style="float: right; color: black;" class="tab" onclick="gem_help();"><span title="click here and than what you are interested in">Click And Help</span></li>
+        {{ tab_content|safe }}
         {% if is_popup %}<li id="id_populate_form" style="float: right; background-color: white; color: red; font-weight: bold;" class="tab" onclick="populate_form();"><span>Populate Form</span></li>{% endif %}
+        <li id="id_help_form" style="float: right; color: black;" class="tab" onclick="gem_help();"><span title="click here and than what you are interested in">{% if is_popup %}Help{% else %}Click and Help{% endif %}</span></li>
+        <li id="id_intro_form" style="float: right; color: black;" class="tab" onclick="window.open('http://www.globalquakemodel.org/what/physical-integrated-risk/building-taxonomy/', '_blank');"><span title="an introduction to building taxonomy">Introduction</span></li>
     </ul>
     <div id="main_content_parent" style="border-top-width: 0; border-color: #F8F8F8 #1B75A7 #1B75A7; position: relative; width: 800px; height: 600px; /* background-color: #ccccff; blue */">
         <div id="main_content-1" class="main_content" style="position: absolute; display: none; top: 0px; width: 800px; margin: 0px;/* background-color: #ffcccc; /*red */">

--- a/openquakeplatform/openquakeplatform/taxtweb/templates/taxtweb/incl_taxtweb_inlinecss.html
+++ b/openquakeplatform/openquakeplatform/taxtweb/templates/taxtweb/incl_taxtweb_inlinecss.html
@@ -185,6 +185,10 @@ div.gem_help_select {
     background-color: #c5e3f2;
 }
 
+#id_intro_form {
+    background-color: #c4f2d7;
+}
+
 div.gem_help_highlight {
     background:rgba(176, 203, 217, 0.5);
     position: absolute;


### PR DESCRIPTION
A new button is added to open a new popup (or tab) to http://www.globalquakemodel.org/what/physical-integrated-risk/building-taxonomy/

Fix #556 
![shot](https://cloud.githubusercontent.com/assets/1670278/13215667/692cf49e-d957-11e5-84c9-75a1b407a1f0.png)
