### PR TITLE
ript: hotfix for Aggregated Structural Costs case syntax error.

### DIFF
--- a/openquakeplatform/openquakeplatform/ript/static/ript/risk_input_model_exposure.js
+++ b/openquakeplatform/openquakeplatform/ript/static/ript/risk_input_model_exposure.js
@@ -367,7 +367,7 @@ $('#saveBtnEX').click(function() {
         // Economic Cost
         if (structuralInx > -1 ) {
             costTypes += '\t\t\t\t<costType name="structural" type="per_asset" unit="USD" />\n';
-            costs += '\t\t\t\t\t<cost type="structural" value="'+ data[i][structuralInx]+'" '+retrofitting+' '+deductibleValue+' '+limitValue+'"/>\n';
+            costs += '\t\t\t\t\t<cost type="structural" value="'+ data[i][structuralInx]+'" '+retrofitting+' '+deductibleValue+' '+limitValue+'/>\n';
         }
         if (non_structuralInx > -1 ) {
             costs += '\t\t\t\t\t<cost type="nonstructural" value="'+ data[i][non_structuralInx]+'"/>\n';


### PR DESCRIPTION
When generating an exposure model using the aggregated value option, and extra “ is written in the output file. I used the attached exposure information (exposure_example.txt) which led to the exposure_example.xml also attached.

It fixes #561.

