### PR TITLE
HRDE: open terms of use in a new tab instead of the current one

### DIFF
--- a/openquakeplatform/openquakeplatform/hrde/static/hrde/hrde.js
+++ b/openquakeplatform/openquakeplatform/hrde/static/hrde/hrde.js
@@ -219,7 +219,7 @@ var startApp = function() {
     });
 
     $('#terms').button().click(function() {
-        window.location = "/account/terms/";
+        window.open('/account/terms/', '_blank');
     });
 
     map = new L.Map('map', {


### PR DESCRIPTION
Otherwise clicking the button would cause to discard whatever you had already done in the hrde.