### PR TITLE
Divide the validate_nrml function into 2 separate functions

### DIFF
--- a/openquakeplatform/openquakeplatform/ript/views.py
+++ b/openquakeplatform/openquakeplatform/ript/views.py
@@ -47,10 +47,7 @@ def _do_validate_nrml(xml_text):
     from openquake.baselib.general import writetmp
     from openquake.commonlib import nrml
     xml_file = writetmp(xml_text, suffix='.xml')
-    try:
-        nrml.parse(xml_file)
-    except:
-        raise
+    nrml.parse(xml_file)
 
 
 def validate_nrml(request):

--- a/openquakeplatform/openquakeplatform/ript/views.py
+++ b/openquakeplatform/openquakeplatform/ript/views.py
@@ -119,11 +119,6 @@ def sendback_nrml(request):
             'Please provide the "xml_text" parameter')
     known_func_types = [
         'exposure', 'fragility', 'vulnerability', 'sites_conditions']
-    # FIXME: decide if we want func_type to be mandatory or included in a
-    #        predefined set of known types
-    # if not func_type in known_func_types:
-    #     return HttpResponseBadRequest(
-    #         'Please provide the "func_type" parameter')
     try:
         _do_validate_nrml(xml_text)
     except:


### PR DESCRIPTION
From `validate_nrml` I extracted `validate_nrml` and `sendback_nrml`. I placed the common code into a third function `_do_validate_nrml`