### PR TITLE
Renamed fab argument host to hostname because the first is reserved.

### DIFF
--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -76,7 +76,7 @@ of these solutions:
 """
 
 def bootstrap(db_name=None, db_user=None,
-              db_pass=DB_PASSWORD, host='oq-platform.localdomain',
+              db_pass=DB_PASSWORD, hostname='oq-platform.localdomain',
               geonode_port=None,
               geoserver_port=None,
               hazard_calc_addr='http://oq-platform.localdomain:8800',
@@ -118,7 +118,7 @@ def bootstrap(db_name=None, db_user=None,
     oq_secret_key = ''.join(random.choice(string.ascii_letters + string.digits
                     + '%$&()=+-|#@?') for _ in range(50))
 
-    baseenv(host, db_name=db_name, db_user=db_user, db_pass=db_pass,
+    baseenv(hostname, db_name=db_name, db_user=db_user, db_pass=db_pass,
             geonode_port=geonode_port, geoserver_port=geoserver_port,
             hazard_calc_addr=hazard_calc_addr,
             risk_calc_addr=risk_calc_addr, oq_engserv_key=oq_engserv_key,
@@ -143,7 +143,7 @@ def bootstrap(db_name=None, db_user=None,
     #    _pgquery('ALTER USER %s WITH NOSUPERUSER' % db_user)
     _check_risklib_nrmllib()
 
-def baseenv(host, db_name='oqplatform', db_user='oqplatform', db_pass=DB_PASSWORD,
+def baseenv(hostname, db_name='oqplatform', db_user='oqplatform', db_pass=DB_PASSWORD,
             geonode_port=None, geoserver_port=None,
             hazard_calc_addr='http://oq-platform.localdomain:8800',
             risk_calc_addr='http://oq-platform.localdomain:8800',
@@ -160,7 +160,7 @@ def baseenv(host, db_name='oqplatform', db_user='oqplatform', db_pass=DB_PASSWOR
     if mediaroot is None:
         mediaroot = os.path.join(os.getcwd(), "uploaded")
 
-    _write_local_settings(host, db_name, db_user, db_pass, geonode_port, geoserver_port, hazard_calc_addr, risk_calc_addr, oq_engserv_key, oq_secret_key, oq_bing_key, mediaroot, staticroot)
+    _write_local_settings(hostname, db_name, db_user, db_pass, geonode_port, geoserver_port, hazard_calc_addr, risk_calc_addr, oq_engserv_key, oq_secret_key, oq_bing_key, mediaroot, staticroot)
     # Create the user if it doesn't already exist
     # User will have superuser privileges for running
     # syncdb (part of `paver setup` below), etc.
@@ -297,20 +297,20 @@ def test_with_xunit():
           '--xunit-file=../nosetests.xml')
 
 
-def _write_local_settings(host, db_name, db_user, db_pass,
+def _write_local_settings(hostname, db_name, db_user, db_pass,
                           geonode_port, geoserver_port,
                           hazard_calc_addr, risk_calc_addr,
                           oq_engserv_key, oq_secret_key,
                           oq_bing_key, mediaroot, staticroot):
     local_settings = open(GEM_LOCAL_SETTINGS_TMPL, 'r').read()
     with open('openquakeplatform/local_settings.py', 'w') as fh:
-        fh.write(local_settings % dict(host=host,
+        fh.write(local_settings % dict(hostname=hostname,
                                        db_name=db_name,
                                        db_user=db_user,
                                        db_pass=db_pass,
                                        geonode_port=geonode_port,
                                        geoserver_port=geoserver_port,
-                                       siteurl="%s:%s" % (host, geonode_port),
+                                       siteurl="%s:%s" % (hostname, geonode_port),
                                        hazard_calc_addr=hazard_calc_addr,
                                        risk_calc_addr=risk_calc_addr,
                                        oq_engserv_key=oq_engserv_key,

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -78,9 +78,9 @@ BING_KEY = {
 
 # FIXME production doesn't work without 'testserver'.
 # Production must be fixed and 'testserver' removed from here.
-ALLOWED_HOSTS = ['%(host)s', 'testserver', 'localhost']
+ALLOWED_HOSTS = ['%(hostname)s', 'testserver', 'localhost']
 
-PROXY_ALLOWED_HOSTS = ('%(host)s', 'localhost')
+PROXY_ALLOWED_HOSTS = ('%(hostname)s', 'localhost')
 
 MEDIA_ROOT = '%(mediaroot)s'
 STATIC_ROOT = '%(staticroot)s'
@@ -393,8 +393,8 @@ AUTH_EXEMPT_URLS = ('/$',
 # EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 # EMAIL_HOST = 'localhost'
 # EMAIL_PORT = 25
-# DEFAULT_FROM_EMAIL = 'info@%(host)s'
-# THEME_ACCOUNT_CONTACT_EMAIL = 'info@%(host)s'
+# DEFAULT_FROM_EMAIL = 'info@%(hostname)s'
+# THEME_ACCOUNT_CONTACT_EMAIL = 'info@%(hostname)s'
 
 # this value must be the same of oq-engine-server key settings
 OQ_ENGINE_SERVER_DATABASE = "%(oq_engserv_key)s"


### PR DESCRIPTION
Fabric us host as reserved variable to specify the name of target host to try to perform installation instead of localhost, hiding the argument 'host' of target function.