### PR TITLE
IRV - When clicking on the map, show zonal information in a more structured way

### DIFF
--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1034,6 +1034,8 @@ function mapboxGlLayerCreation() {
                 // if the name is undefined, but the field was found, then return the field
                 return field;
             }
+        } else if (treeNode.name !== 'undefined' && treeNode.name == field) {
+            return field;
         } else if (typeof treeNode.children !== 'undefined') {
             for (var i = 0; i < treeNode.children.length; i++) {
                 var child = treeNode.children[i];
@@ -1061,14 +1063,11 @@ function mapboxGlLayerCreation() {
                 // do not show info
             }
             if (typeof features[0] !== 'undefined' && typeof features[0].properties !== 'undefined') {
-                console.log(features[0].properties);
                 for (var field in features[0].properties) {
                     var name = findNameInProjDef(field, sessionProjectDef);
                     if (name) {
                         var value = features[0].properties[field];
                         $('#mapInfo').append(name + ': ' + value + '</br>');
-                    } else {
-                        console.log(field);
                     }
                 }
             } else {

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1107,6 +1107,10 @@ function mapboxGlLayerCreation() {
                                 break;
                             case nodeTypes.RISK_INDICATOR:
                                 structuredInfo.riskIndicators.push(nameAndValue);
+                                break;
+                            default:
+                                // This should never happen, unless the project definition is wrong
+                                alert('Wrong project definition: unknown node type [' + nameAndType.type + ']');
                         }
                     }
                 }

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1034,17 +1034,16 @@ function mapboxGlLayerCreation() {
                 // if the name is undefined, but the field was found, then return the field
                 return field;
             }
-        } else if (typeof treeNode.children !== 'undefined'){
+        } else if (typeof treeNode.children !== 'undefined') {
             for (var i = 0; i < treeNode.children.length; i++) {
-                try {
-                    var name = findNameInProjDef(field, treeNode.children[i]);
+                var child = treeNode.children[i];
+                var name = findNameInProjDef(field, child);
+                if (name) {
                     return name;
-                } catch (exc) {
-                    // keep iterating on children
                 }
             }
         } else {
-            throw "Not found";
+            return false;
         }
     }
 
@@ -1062,16 +1061,14 @@ function mapboxGlLayerCreation() {
                 // do not show info
             }
             if (typeof features[0] !== 'undefined' && typeof features[0].properties !== 'undefined') {
+                console.log(features[0].properties);
                 for (var field in features[0].properties) {
-                    var name;
-                    try {
-                        name = findNameInProjDef(field, sessionProjectDef);
-                    } catch (exc) {
-                        // do not show fields that are not in the project definition
-                    }
-                    if (typeof name !== 'undefined') {
+                    var name = findNameInProjDef(field, sessionProjectDef);
+                    if (name) {
                         var value = features[0].properties[field];
                         $('#mapInfo').append(name + ': ' + value + '</br>');
+                    } else {
+                        console.log(field);
                     }
                 }
             } else {

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -1112,14 +1112,16 @@ function mapboxGlLayerCreation() {
                 }
             }
             if (isDataAvailable) {
-                for (var key in structuredInfo) {
-                    $('#mapInfo').append('<hr>');
+                $.each(['compositeIndices', 'riskIndicators', 'svThemes', 'svIndicators'], function(ind, key) {
+                    if (structuredInfo[key].length) {
+                        $('#mapInfo').append('<hr>');
+                    }
                     for (var i = 0; i < structuredInfo[key].length; i++) {
                         var name = structuredInfo[key][i].name;
                         var value = structuredInfo[key][i].value;
                         $('#mapInfo').append(name + ': ' + value + '</br>');
                     }
-                }
+                });
             } else {
                 $('#mapInfo').append('No data available');
             }


### PR DESCRIPTION
Partially addressing https://github.com/gem/oq-platform/issues/583

With this change, instead of just displaying the raw and unsorted data, the application searches the extended names and types of variables by scanning the project definition. Then the variables are presented in a structured way, collected by type.

Tests are green: https://ci.openquake.org/job/zdevel_oq-platform/252/