### PR TITLE
Improve and update the calculate page

### DIFF
--- a/openquakeplatform/openquakeplatform/templates/calculate.html
+++ b/openquakeplatform/openquakeplatform/templates/calculate.html
@@ -31,9 +31,12 @@
             <b>The OpenQuake Engine:</b><br/>
             Seismic hazard and risk calculations can be performed using the OpenQuake engine.
             <ul>
-                <li><a href="http://www.globalquakemodel.org/openquake/about/engine/" target="_blank">learn</a> more about the Engine and it's calculators</li>
+                <li><a href="" target="_blank">learn</a> more about the Engine and it's calculators</li>
                 <li>
-                  <a href="http://www.globalquakemodel.org/openquake/support/documentation/engine/" target="_blank">OpenQuake Engine Main Documentation page</a>
+                  <a href="https://github.com/gem/oq-engine#openquake-engine" target="_blank">OpenQuake Engine</a>
+                </li>
+                <li>
+                  <a href="https://github.com/GEMScienceTools/oq-engine-docs/raw/engine-2.0/oq-manual.pdf" target="_blank">OpenQuake Engine manual</a>
                 </li>
             </ul>
 
@@ -43,16 +46,13 @@
               </ul>
             <b>Calculate on a desktop computer or server:</b>
               <ul>
-                <li><a href="http://www.globalquakemodel.org/openquake/start/download/" target="_blank">Download the OpenQuake Engine</a></li>
+                <li><a href="https://github.com/gem/oq-engine#installation" target="_blank">Download the OpenQuake Engine</a></li>
               </ul>
 
             <b>Libraries:</b>
               <ul>
                 <li>
                   <a href="https://github.com/gem/oq-hazardlib" target="_blank">oq-hazardlib</a> - Openquake Hazard Library
-                </li>
-                <li>
-                  <a href="https://github.com/gem/oq-engine" target="_blank">oq-engine</a> - OpenQuake Risk Library
                 </li>
               </ul>
 
@@ -81,9 +81,6 @@
 
             <b>Supporting material:</b>
               <ul>
-                <li>
-                  <a href="http://www.globalquakemodel.org/openquake/support/documentation/engine/#manual-latest-stable" target="_blank">OpenQuake Engine manual</a>
-                </li>
                 <li>
                   GEM respository for <a href="https://github.com/GEMScienceTools/notebooks" target="_blank">ipython notebook examples</a> demonstrating use of GEM scientific libraries (e.g., oq-hazardlib, hmtk etc.)
                 </li>

--- a/openquakeplatform/openquakeplatform/templates/calculate.html
+++ b/openquakeplatform/openquakeplatform/templates/calculate.html
@@ -31,12 +31,9 @@
             <b>The OpenQuake Engine:</b><br/>
             Seismic hazard and risk calculations can be performed using the OpenQuake engine.
             <ul>
-                <li><a href="" target="_blank">learn</a> more about the Engine and it's calculators</li>
+                <li><a href="https://github.com/gem/oq-engine#openquake-engine" target="_blank">learn more</a> about the Engine and it's calculators</li>
                 <li>
-                  <a href="https://github.com/gem/oq-engine#openquake-engine" target="_blank">OpenQuake Engine</a>
-                </li>
-                <li>
-                  <a href="https://github.com/GEMScienceTools/oq-engine-docs/raw/engine-2.0/oq-manual.pdf" target="_blank">OpenQuake Engine manual</a>
+                  read the <a href="https://github.com/GEMScienceTools/oq-engine-docs/raw/engine-2.0/oq-manual.pdf" target="_blank">OpenQuake Engine manual</a>
                 </li>
             </ul>
 


### PR DESCRIPTION
For the Engine 2.0

Now the links are pointing directly to the resources and they don't link to the website anymore (which is not well maintained).

I would suggest to improve more this page and remove pages for the website, making it just pointing here.
