### PR TITLE
vulnerability: 'taxonomy_text' field must be declared as not required

### DIFF
--- a/openquakeplatform/openquakeplatform/vulnerability/forms.py
+++ b/openquakeplatform/openquakeplatform/vulnerability/forms.py
@@ -127,6 +127,7 @@ class GeneralInformationForm(BaseNestedModelForm):
         attrs={'style': 'width: 500px;', }))
     gem_was_clone = forms.CharField(widget=forms.HiddenInput(), required=False)
     taxonomy_text = TaxonomyInputField(
+        required=False,
         max_length=1023,
         widget=TaxonomyInput(
             attrs={'style': 'margin-left: 16px;'


### PR DESCRIPTION
Without this fix an empty `taxonomy_text` value generates an error message and not allows to save the curve.
