### PR TITLE
IRV - Custom operator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 python-oq-platform (1.7.1)
+  
+  [Paolo Tormene]
+  * irv: enable visualizing projects in which the IRI was calculated using a custom
+    operator, and do not allow to change weights in case other nodes are custom.
 
   [Daniele Viganò]
   * Add Creative Commons 4 licenses

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -63,6 +63,11 @@ var operators = {
         'code': 'GEOM_MEAN',
         'ignoresWeights': true,
         'multiplies': true
+    },
+    'CUSTOM': {
+        'code': 'CUSTOM',
+        'ignoresWeights': true,
+        'multiplies': false
     }
 };
 
@@ -72,7 +77,8 @@ var namesToOperators = {
     'Average (ignore weights)':               operators.AVG,
     'Simple multiplication (ignore weights)': operators.MUL_S,
     'Weighted multiplication':                operators.MUL_W,
-    'Geometric mean (ignore weights)':        operators.GEOM_MEAN
+    'Geometric mean (ignore weights)':        operators.GEOM_MEAN,
+    'Use a custom field (no recalculation)':  operators.CUSTOM
 };
 
 var nodeTypes = {
@@ -540,6 +546,14 @@ function processIndicators(layerAttributes, projectDef) {
     var IRI = {};
     if (svThemes === undefined || riskIndicators === undefined) {
         //return;
+    } else if (namesToOperators[projectDef.operator].code == 'CUSTOM') {
+        // the IRI operator is set to use a custom field without recalculating
+        var la = layerAttributes.features;
+        for (var s = 0; s < la.length; s++) {
+            var regionName = la[s].properties[zoneLabelField];
+            IRI[regionName] = la[s].properties[projectDef.field];
+        }
+        scale(IRI);
     } else {
         var sviWeight;
         var riWeight;

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -369,13 +369,16 @@
         d3.select(self.frameElement).style("height", "800px");
 
         function onTreeWeightClick(d) {
+            $('#projectDefWeightDialog').empty();
+            if (!projDefOperatorsAreSupported) {
+                return;
+            }
             pdName = d.name;
             pdData = data;
             pdWeight = d.weight;
             pdLevel = d.level;
             pdTempSpinnerIds = [];
             pdTempIds = [];
-            $('#projectDefWeightDialog').empty();
             findTreeBranchInfo(pdData, [pdName], [pdLevel]);
             updateButton();
         }

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -462,7 +462,7 @@
                     if (d.children){
                         var operator = d.operator? d.operator : DEFAULT_OPERATOR;
                         d.operator = operator;
-                        if (operator.indexOf('ignore weights') != -1) {
+                        if (operator.indexOf('ignore weights') != -1 || operator.indexOf('no recalculation') != -1) {
                             parts = operator.split('(');
                             operator = parts[0];
                         }
@@ -486,7 +486,7 @@
                 .text(function(d) {
                     if (d.children){
                         var ignoreWeightsStr = '';
-                         if (d.operator.indexOf('ignore weights') != -1) {
+                         if (d.operator.indexOf('ignore weights') != -1 || d.operator.indexOf('no recalculation') != -1) {
                             parts = d.operator.split('(');
                             ignoreWeightsStr = '(' + parts[1];
                         }

--- a/openquakeplatform/openquakeplatform/irv/templates/irv/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/irv/templates/irv/irv_viewer.html
@@ -77,6 +77,13 @@ IRV - {{block.super}}
     </ul>
     <div id="project-def">
         <button id="saveBtn" class="btn btn-blue">Save Project Definition</button>
+        <div id="mainContainer">
+            <div class="alert-unsupported-operators">
+                <div class="alert alert-danger" role="alert">
+                    Custom operators are used in nodes different than IRI, so the modification of weights is not supported.
+                </div>
+            </div>
+        </div>
         <div id="tool-tip"></div>
         <div id="projectDef-tree"></div>
         <div id="projectDefDialog" title="Project Definition">


### PR DESCRIPTION
This PR enables the Integrated Risk Viewer (IRV) to visualize projects in which the Integrated Risk was obtained through a custom calculation. In this case, the IRI will not be recalculated, and its values will just be read from a field specified by the user. The project definition also contains a description of the customized calculation.

Please see the companion: https://github.com/gem/oq-irmt-qgis/pull/146

In my local machine tests are green.