### PR TITLE
irv: disable changing weights in all projects using custom operators

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 python-oq-platform (1.7.1)
   
   [Paolo Tormene]
-  * irv: enable visualizing projects in which the IRI was calculated using a custom
-    operator, and do not allow to change weights in case other nodes are custom.
+  * irv: enable visualizing projects in which one or more composite indices were
+    calculated using custom operators, and disable changing weights in such cases.
 
   [Daniele Viganò]
   * Add Creative Commons 4 licenses

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -108,6 +108,9 @@ var primaryChartElems = {"graph": "primaryGraph",
 var chartElems = {"iri": iriChartElems, "theme": themeChartElems, "primary": primaryChartElems};
 
 $(document).ready(function() {
+    var baseMapUrl = new L.TileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+    var app = new OQLeaflet.OQLeafletApp(baseMapUrl);
+    app.initialize(startApp);
     $('#cover').remove();
     // FIXME: We are never showing alert-unscaled-data currently
     $('.alert-unscaled-data').hide();
@@ -139,8 +142,6 @@ var mappingLayerAttributes = {};
 // While projectDef includes modified weights and is no longer the version that was uploaded from the QGIS tool
 var projectLayerAttributes;
 var regionNames = [];
-var baseMapUrl = new L.TileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
-var app = new OQLeaflet.OQLeafletApp(baseMapUrl);
 var indicatorChildrenKey = [];
 var projDefOperatorsAreStandard = false;
 
@@ -2027,5 +2028,3 @@ function projDefJSONRequest(selectedLayer) {
 function triggerPdSelection () {
     $('#pdSelection').trigger('change');
 }
-
-app.initialize(startApp);

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -111,7 +111,7 @@ $(document).ready(function() {
     $('#cover').remove();
     // FIXME: We are never showing alert-unscaled-data currently
     $('.alert-unscaled-data').hide();
-    $('.alert-unsupported-operators').hide();
+    $('.alert-custom-operators').hide();
     $('#absoluteSpinner').hide();
     $('#loadProjectBtn').show();
 });
@@ -142,7 +142,7 @@ var regionNames = [];
 var baseMapUrl = new L.TileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
 var app = new OQLeaflet.OQLeafletApp(baseMapUrl);
 var indicatorChildrenKey = [];
-var projDefOperatorsAreSupported = false;
+var projDefOperatorsAreStandard = false;
 
 function setWidgetsToDefault(){
     $('#pdSelection').empty();
@@ -330,9 +330,6 @@ function combineIndicators(nameLookUp, themeObj, JSONthemes) {
 }
 
 function processIndicators(layerAttributes, projectDef) {
-    if (!projDefOperatorsAreSupported) {
-        return;
-    }
     var weightChange = 0;
     if (arguments[2]) {
         weightChange = arguments[2];
@@ -1477,12 +1474,12 @@ function whenProjDefSelected() {
         if (tempProjectDef[i].title === pdSelection) {
             // Deep copy the temp project definition object
             sessionProjectDef = jQuery.extend(true, {}, tempProjectDef[i]);
-            if (has_non_root_custom_fields(sessionProjectDef)) {
-                projDefOperatorsAreSupported = false;
-                $('.alert-unsupported-operators').show();
+            if (has_custom_fields(sessionProjectDef)) {
+                projDefOperatorsAreStandard = false;
+                $('.alert-custom-operators').show();
             } else {
-                projDefOperatorsAreSupported = true;
-                $('.alert-unsupported-operators').hide();
+                projDefOperatorsAreStandard = true;
+                $('.alert-custom-operators').hide();
             }
             loadPD(sessionProjectDef);
             $('#iri-spinner').hide();
@@ -1492,12 +1489,13 @@ function whenProjDefSelected() {
     }
 }
 
-function has_non_root_custom_fields(projDef) {
+function has_custom_fields(projDef) {
+    if (typeof(projDef.operator) !== 'undefined' && namesToOperators[projDef.operator].code == 'CUSTOM') {
+        return true;
+    }
     for (var childIdx in projDef.children) {
         var child = projDef.children[childIdx];
-        if (typeof(child.operator) !== 'undefined' && namesToOperators[child.operator].code == 'CUSTOM') {
-            return true;
-        } else if (has_non_root_custom_fields(child)) {
+        if (has_custom_fields(child)) {
             return true;
         }
     }

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -370,7 +370,7 @@
 
         function onTreeWeightClick(d) {
             $('#projectDefWeightDialog').empty();
-            if (!projDefOperatorsAreSupported) {
+            if (!projDefOperatorsAreStandard) {
                 return;
             }
             pdName = d.name;

--- a/openquakeplatform/openquakeplatform/irv/static/irv/spec/SpecIRV.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/spec/SpecIRV.js
@@ -183,7 +183,10 @@ describe("Get All Layers From GeoServer", function() {
                 'CC0 (http://creativecommons.org/about/cc0)',
                 'CC BY 3.0  (http://creativecommons.org/licenses/by/3.0/)',
                 'CC BY-SA 3.0 (http://creativecommons.org/licenses/by-sa/3.0/)',
-                'CC BY-NC-SA 3.0 (http://creativecommons.org/licenses/by-nc-sa/3.0/)'
+                'CC BY-NC-SA 3.0 (http://creativecommons.org/licenses/by-nc-sa/3.0/)',
+                'CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)',
+                'CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/',
+                'CC BY-NC-SA 4.0 (https://creativecommons.org/licenses/by-nc-sa/4.0/'
             ];
             expect(licenseOptions).toContain(tempLicense);
 

--- a/openquakeplatform/openquakeplatform/irv/templates/irv/irv_viewer.html
+++ b/openquakeplatform/openquakeplatform/irv/templates/irv/irv_viewer.html
@@ -78,9 +78,9 @@ IRV - {{block.super}}
     <div id="project-def">
         <button id="saveBtn" class="btn btn-blue">Save Project Definition</button>
         <div id="mainContainer">
-            <div class="alert-unsupported-operators">
+            <div class="alert-custom-operators">
                 <div class="alert alert-danger" role="alert">
-                    Custom operators are used in nodes different than IRI, so the modification of weights is not supported.
+                    Custom operators are used, so the modification of weights is not supported.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
For simplicity, I prefer to disable changing weights whenever any of the nodes in the current project uses a custom operator. Before, I was allowing to change weights in the single case in which the IRI node was using a custom operator, but not the others. I found a little bug in that solution, and anyway I prefer to keep things a little simpler.
There was also a case in which the map was not displayed, so I fixed it too.