### PR TITLE
IRV: enable reading projects using a modified custom operator format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-python-oq-platform (1.8.0)
+python-oq-platform (1.7.2)
   [Paolo Tormene]
-  * irv: accept custom operators defined with the modified format
+  * irv: accept also a modified format of custom operators and display the formula
+    that was used to calculate the custom field (or a textual description)
 
 python-oq-platform (1.7.1)
   

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+python-oq-platform (1.8.0)
+  [Paolo Tormene]
+  * irv: accept custom operators defined with the modified format
+
 python-oq-platform (1.7.1)
   
   [Paolo Tormene]

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer.js
@@ -78,6 +78,8 @@ var namesToOperators = {
     'Simple multiplication (ignore weights)': operators.MUL_S,
     'Weighted multiplication':                operators.MUL_W,
     'Geometric mean (ignore weights)':        operators.GEOM_MEAN,
+    'Use a custom field':                     operators.CUSTOM,
+    // the following is for backwards compatibility
     'Use a custom field (no recalculation)':  operators.CUSTOM
 };
 

--- a/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
+++ b/openquakeplatform/openquakeplatform/irv/static/irv/js/irv_viewer_d3_tree.js
@@ -465,7 +465,7 @@
                     if (d.children){
                         var operator = d.operator? d.operator : DEFAULT_OPERATOR;
                         d.operator = operator;
-                        if (operator.indexOf('ignore weights') != -1 || operator.indexOf('no recalculation') != -1) {
+                        if (operator.indexOf('ignore weights') != -1) {
                             parts = operator.split('(');
                             operator = parts[0];
                         }
@@ -488,13 +488,23 @@
             nodeEnter.append("text")
                 .text(function(d) {
                     if (d.children){
-                        var ignoreWeightsStr = '';
-                         if (d.operator.indexOf('ignore weights') != -1 || d.operator.indexOf('no recalculation') != -1) {
+                        if (d.operator.indexOf('ignore weights') != -1) {
                             parts = d.operator.split('(');
-                            ignoreWeightsStr = '(' + parts[1];
+                            var ignoreWeightsStr = '(' + parts[1];
+                            return ignoreWeightsStr;
                         }
-                        return ignoreWeightsStr;
+                        if (d.operator.indexOf('custom') != -1) {
+                            var customString = '';
+                            if (typeof d.customFormula !== 'undefined') {
+                                customString += '(' + d.customFormula + ')';
+                            }
+                            else if (typeof d.fieldDescription !== 'undefined') {
+                                customString += '(' + d.fieldDescription + ')';
+                            }
+                            return customString;
+                        }
                     }
+                    return '';
                 })
                 .style("fill", function(d) {
                     if (d.operator != 'undefined') {


### PR DESCRIPTION
I am keeping backwards compatibility, so the old projects can still be visualized.
With the proposed changes, the IRV will be able to read also projects created by the IRMT QGIS plugin after the changes introduced in the following commit:
https://github.com/gem/oq-irmt-qgis/commit/03b8a3d15c31cdc7b852a7b3ad4aa0bdade8a6e0
While displaying the tree, the IRV will visualize also the custom formula or its textual description, if they are specified in the project definition.
Jasmine tests are green.