### PR TITLE
FIx platform installation

### DIFF
--- a/docs/Development-environment-on-Ubuntu-12.04.md
+++ b/docs/Development-environment-on-Ubuntu-12.04.md
@@ -38,8 +38,8 @@ sudo add-apt-repository -y ppa:openquake/ppa
 sudo apt-get update
 sudo apt-get install python-decorator python-h5py python-psutil python-concurrent.futures python-pyshp python-scipy python-numpy python-shapely python-mock python-requests python-docutils
 
-pip install 'http://github.com/gem/oq-hazardlib/tarball/master'
-pip install 'http://github.com/gem/oq-engine/tarball/master'
+pip install --no-deps 'http://github.com/gem/oq-hazardlib/tarball/master'
+pip install --no-deps 'http://github.com/gem/oq-engine/tarball/master'
 ```
 
 Note: `oq-hazardlib` and `oq-engine` can be manually fetched from github and made available via `PYTHONPATH` before running any python application.

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -530,8 +530,8 @@ oq_platform_install () {
     # add dependencies to use nrml validation as library
     apt-get install -y --force-yes python-decorator python-h5py python-psutil python-concurrent.futures python-pyshp python-scipy python-numpy python-shapely python-mock python-requests python-docutils
 
-    pip install https://github.com/gem/oq-hazardlib/archive/stable.zip
-    pip install https://github.com/gem/oq-engine/archive/stable.zip
+    pip install --no-deps openquake.hazardlib
+    pip install --no-deps openquake.engine
 
     # FIXME this code will be used in the future
     ## check for oq-platform packaged dependencies

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -49,18 +49,12 @@ GEM_LOCAL_SETTINGS_TMPL = 'openquakeplatform/local_settings.py.template'
 
 def _check_risklib_nrmllib():
     try:
-        local('python -c "from openquake.commonlib import nrml" >/dev/null 2>&1')
+        local('python -c "from openquake.hazardlib import nrml" >/dev/null 2>&1')
     except SystemExit:
         print """
-WARNING: 'openquake.commonlib.nrml' from 'oq-engine' not found,
+WARNING: 'openquake.hazardlib.nrml' from 'oq-hazardlib' not found,
 'ipt' application will not work properly; to add it you can choose one
 of these solutions:
-
-- install 'oq-hazardlib' and 'oq-engine' as packages running:
-   sudo apt-get install python-software-properties
-   sudo add-apt-repository ppa:openquake/ppa
-   sudo apt-get update
-   sudo apt-get install python-decorator python-h5py python-psutil python-concurrent.futures python-oq-hazardlib python-oq-engine
 
 - install 'oq-hazardlib' and 'oq-engine' packages with pip directly from git running:
    sudo apt-get install python-software-properties

--- a/verifier.sh
+++ b/verifier.sh
@@ -325,7 +325,6 @@ _devtest_innervm_run () {
     scp .gem_init.sh ${lxc_ip}:
     scp .gem_ffox_init.sh ${lxc_ip}:
 
-    # build oq-hazardlib speedups and put in the right place
     ssh -t  $lxc_ip "source .gem_init.sh"
 
     ssh -t  $lxc_ip "rm -f ssh.log"
@@ -394,12 +393,8 @@ if dpkg -l python-simplejson 2>/dev/null | tail -n +6 | grep -q '^ii '; then
     pip install simplejson==2.0.9
 fi
 cd -
-cd oq-platform-ipt
-sudo python setup.py install
-cd -
-cd oq-platform-taxtweb
-sudo python setup.py install
-cd -
+pip install --no-deps -e oq-platform-ipt/
+pip install --no-deps -e oq-platform-taxtweb/
 cd ~/$GEM_GIT_PACKAGE
 
 pip install -e openquakeplatform

--- a/verifier.sh
+++ b/verifier.sh
@@ -383,19 +383,19 @@ source platform-env/bin/activate
 
 # Setup.py has requirements too high for Precise.
 # We do not want to change them because Engine and Hazardlib
-# aren't tested anymore with Precise's stack
+# aren't tested anymore with Precise's stack, so --no-deps is
+# used. We need it for oq-platform-* too because pip tries to
+# resolve dependencies of dependencies too.
 pip install --no-deps openquake.hazardlib
 pip install --no-deps openquake.engine
+pip install --no-deps -e oq-platform-ipt/
+pip install --no-deps -e oq-platform-taxtweb/
 
 # if host machine includes python-simplejson package it must overrided with
 # a proper version that don't conflict with Django requirements
 if dpkg -l python-simplejson 2>/dev/null | tail -n +6 | grep -q '^ii '; then
     pip install simplejson==2.0.9
 fi
-cd -
-pip install --no-deps -e oq-platform-ipt/
-pip install --no-deps -e oq-platform-taxtweb/
-cd ~/$GEM_GIT_PACKAGE
 
 pip install -e openquakeplatform
 cd openquakeplatform

--- a/verifier.sh
+++ b/verifier.sh
@@ -592,9 +592,9 @@ _prodtest_innervm_run () {
 
     repo_id="$GEM_GIT_REPO"
     ssh -t  $lxc_ip "git clone --depth=1 -b $branch_id $repo_id/$GEM_GIT_PACKAGE"
-    ssh -t  $lxc_ip "git clone --depth=1 -b $branch_id $repo_id/oq-moon || git clone --depth=1 -b  $repo_id/oq-moon"
-    ssh -t  $lxc_ip "git clone --depth=1 -b $branch_id $repo_id/oq-platform-ipt || git clone --depth=1 -b  $repo_id/oq-platform-ipt"
-    ssh -t  $lxc_ip "git clone --depth=1 -b $branch_id $repo_id/oq-platform-taxtweb || git clone --depth=1 -b  $repo_id/oq-platform-taxtweb"
+    ssh -t  $lxc_ip "git clone --depth=1 -b $branch_id $repo_id/oq-moon || git clone --depth=1 $repo_id/oq-moon"
+    ssh -t  $lxc_ip "git clone --depth=1 -b $branch_id $repo_id/oq-platform-ipt || git clone --depth=1 $repo_id/oq-platform-ipt"
+    ssh -t  $lxc_ip "git clone --depth=1 -b $branch_id $repo_id/oq-platform-taxtweb || git clone --depth=1 $repo_id/oq-platform-taxtweb"
     ssh -t  $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG
 rem_sig_hand() {
     trap ERR

--- a/verifier.sh
+++ b/verifier.sh
@@ -381,6 +381,10 @@ fi
 cd ~/$GEM_GIT_PACKAGE
 virtualenv --system-site-packages platform-env
 source platform-env/bin/activate
+
+# Setup.py has requirements too high for Precise.
+# We do not want to change them because Engine and Hazardlib
+# aren't tested anymore with Precise's stack
 pip install --no-deps openquake.hazardlib openquake.engine
 
 # if host machine includes python-simplejson package it must overrided with

--- a/verifier.sh
+++ b/verifier.sh
@@ -632,7 +632,7 @@ init_file=\"\$(python -c 'import openquake ; print openquake.__path__[0]')/__ini
 sudo cp /tmp/new_init.py \"\${init_file}\" ;
 sudo python -m py_compile \"\${init_file}\"
 
-export PYTHONPATH=\$(pwd):\$(pwd)/../../oq-moon:\$(pwd)/openquakeplatform/test/config
+export PYTHONPATH=\$(pwd):\$HOME/oq-moon:\$(pwd)/openquakeplatform/test/config
 sed 's@^pla_basepath *= *\"http://localhost:8000\"@pla_basepath = \"http://oq-platform.localdomain\"@g' openquakeplatform/test/config/moon_config.py.tmpl > openquakeplatform/test/config/moon_config.py
 export DISPLAY=:1
 python -m openquake.moon.nose_runner --failurecatcher prod -v --with-xunit --xunit-file=xunit-platform-prod.xml openquakeplatform/test # || true

--- a/verifier.sh
+++ b/verifier.sh
@@ -381,8 +381,7 @@ fi
 cd ~/$GEM_GIT_PACKAGE
 virtualenv --system-site-packages platform-env
 source platform-env/bin/activate
-pip install https://github.com/gem/oq-hazardlib/archive/stable.zip
-pip install https://github.com/gem/oq-engine/archive/stable.zip
+pip install openquake.engine
 
 # if host machine includes python-simplejson package it must overrided with
 # a proper version that don't conflict with Django requirements

--- a/verifier.sh
+++ b/verifier.sh
@@ -385,7 +385,8 @@ source platform-env/bin/activate
 # Setup.py has requirements too high for Precise.
 # We do not want to change them because Engine and Hazardlib
 # aren't tested anymore with Precise's stack
-pip install --no-deps openquake.hazardlib openquake.engine
+pip install --no-deps openquake.hazardlib
+pip install --no-deps openquake.engine
 
 # if host machine includes python-simplejson package it must overrided with
 # a proper version that don't conflict with Django requirements

--- a/verifier.sh
+++ b/verifier.sh
@@ -388,8 +388,8 @@ source platform-env/bin/activate
 # resolve dependencies of dependencies too.
 pip install --no-deps openquake.hazardlib
 pip install --no-deps openquake.engine
-pip install --no-deps -e oq-platform-ipt
-pip install --no-deps -e oq-platform-taxtweb
+pip install --no-deps -e \$HOME/oq-platform-ipt
+pip install --no-deps -e \$HOME/oq-platform-taxtweb
 
 # if host machine includes python-simplejson package it must overrided with
 # a proper version that don't conflict with Django requirements
@@ -439,7 +439,7 @@ python ./manage.py loaddata dev-data.json.bz2
 
 
 
-export PYTHONPATH=\$(pwd):\$(pwd)/../../oq-moon:\$(pwd)/openquakeplatform/test/config
+export PYTHONPATH=\$(pwd):\$HOME/oq-moon:\$(pwd)/openquakeplatform/test/config
 cp openquakeplatform/test/config/moon_config.py.tmpl openquakeplatform/test/config/moon_config.py
 export DISPLAY=:1
 python -m openquake.moon.nose_runner --failurecatcher dev -v --with-xunit --xunit-file=xunit-platform-dev.xml openquakeplatform/test #  || true

--- a/verifier.sh
+++ b/verifier.sh
@@ -340,8 +340,6 @@ _devtest_innervm_run () {
     ssh -t  $lxc_ip "sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master"
     ssh -t  $lxc_ip "sudo apt-get update"
     ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-decorator python-h5py python-psutil python-concurrent.futures python-pyshp python-scipy python-numpy python-shapely python-mock python-requests python-docutils"
-    ssh -t  $lxc_ip "sudo pip install https://github.com/gem/oq-hazardlib/archive/stable.zip"
-    ssh -t  $lxc_ip "sudo pip install https://github.com/gem/oq-engine/archive/stable.zip"
 
 
     # to allow mixed openquake packages installation (from packages and from sources) an 'ad hoc' __init__.py injection.
@@ -383,6 +381,9 @@ fi
 cd ~/$GEM_GIT_PACKAGE
 virtualenv --system-site-packages platform-env
 source platform-env/bin/activate
+pip install https://github.com/gem/oq-hazardlib/archive/stable.zip
+pip install https://github.com/gem/oq-engine/archive/stable.zip
+
 # if host machine includes python-simplejson package it must overrided with
 # a proper version that don't conflict with Django requirements
 if dpkg -l python-simplejson 2>/dev/null | tail -n +6 | grep -q '^ii '; then

--- a/verifier.sh
+++ b/verifier.sh
@@ -381,7 +381,7 @@ fi
 cd ~/$GEM_GIT_PACKAGE
 virtualenv --system-site-packages platform-env
 source platform-env/bin/activate
-pip install openquake.engine
+pip install --no-deps openquake.hazardlib openquake.engine
 
 # if host machine includes python-simplejson package it must overrided with
 # a proper version that don't conflict with Django requirements

--- a/verifier.sh
+++ b/verifier.sh
@@ -388,8 +388,8 @@ source platform-env/bin/activate
 # resolve dependencies of dependencies too.
 pip install --no-deps openquake.hazardlib
 pip install --no-deps openquake.engine
-pip install --no-deps -e oq-platform-ipt/
-pip install --no-deps -e oq-platform-taxtweb/
+pip install --no-deps -e oq-platform-ipt
+pip install --no-deps -e oq-platform-taxtweb
 
 # if host machine includes python-simplejson package it must overrided with
 # a proper version that don't conflict with Django requirements


### PR DESCRIPTION
There were several issues:

- The installation of engine and hazardlib was trying to download and build dependencies from pip. The 12.04 stack isn't tested and supported in engine and hazardlib, then now we install them with `--no-deps`. This also applies to ipt which has hazardlib + engine in its dependencies.
- Some parts of the installation were still looking for `openquake.commonlib.nrml` instead of `openquake.hazardlib.nrml`
- `oq-moon` git clone had wrong syntax

https://ci.openquake.org/job/zdevel_oq-platform/376

Fixes #626 