### PR TITLE
add 'Building Classification Survey tool' and '?next=' to login form action

### DIFF
--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -370,13 +370,15 @@ AUTH_EXEMPT_URLS = ('/$',
 # FIXME: there's no admin validation on new accounts.
 # REGISTRATION_OPEN = True
 
-# Uncomment to allow open registration.
+# Uncomment to allow open registration and enable EMAIL_BACKEND
+#                   (use '...console.EmailBackend' for devel purposes).
 # This setting define in how many days an account
 # must be verified by the user.
 # ACCOUNT_ACTIVATION_DAYS = 1
 
 # A valid mailserver must be configured to make open registration work.
 # EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+# EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # EMAIL_HOST = 'localhost'
 # EMAIL_PORT = 25
 # DEFAULT_FROM_EMAIL = 'info@%(hostname)s'

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -364,7 +364,8 @@ AUTH_EXEMPT_URLS = ('/$',
                     '/vulnerability/engineering_demand_csc?.*',
                     '/vulnerability/resp_var_par_csc?.*',
                     '/vulnerability/resp_var_units_csc?.*',
-                    '/taxtweb/')
+                    '/taxtweb/',
+                    '/building-class/')
 
 # Uncomment to allow open registration.
 # FIXME: there's no admin validation on new accounts.

--- a/openquakeplatform/openquakeplatform/templates/includes/header.html
+++ b/openquakeplatform/openquakeplatform/templates/includes/header.html
@@ -88,7 +88,11 @@
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans "Sign in" %}</a>
                         <ul class="dropdown-menu">
                           <li>
+                          {% if next %}
+                            <form action="{% url "account_login" %}?next={{next}}" method="post" class="sign-in">
+                          {%else%}
                             <form action="{% url "account_login" %}" method="post" class="sign-in">
+                          {% endif %}
                             {% csrf_token %}
                               <label for="id_username">{% trans "Username" %}:</label>
                               <input id="id_username" name="username" type="text" />

--- a/openquakeplatform/openquakeplatform/templates/share.html
+++ b/openquakeplatform/openquakeplatform/templates/share.html
@@ -39,6 +39,9 @@
               <li>
                 <a href="{% url 'vulnerability.views.list' %}">The Physical Vulnerability suite</a> allows users to explore and contribute to a comprehensive global vulnerability database that includes fragility, vulnerability, damage-to-loss functions and capacity curves for different types of structure.
               </li>
+              <li>
+                <a href="{% url 'building_class:home' %}">The Building Classification Survey tool</a> allows users to share information regarding the building stock of a given region.
+              </li>
             </ul>
 
             <b>Offline Inventory Capture Tools</b>


### PR DESCRIPTION
With this fix we avoid to pass from homepage when we already are landed on "/building-class/" page.
And add a new entry for 'Building Classification Survey tool'  in 'share' page.
Tests are blocked by current broken platform <-> engine interface.
It is companion of gem/oq-platform-building-class/pull/10 PR.
CI is running here: https://ci.openquake.org/job/zdevel_oq-platform/412/