### PR TITLE
Moving from oq-engine as library to oq-engine as web-service

### DIFF
--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -49,8 +49,7 @@ fi
 GEM_DB_NAME='oqplatform'
 GEM_DB_USER='oqplatform'
 GEM_DB_PASS='the-password'
-GEM_HAZARD_CALC_ADDR='http://localhost:8800'
-GEM_RISK_CALC_ADDR='http://localhost:8800'
+GEM_WEBUIURL='http://localhost.localdomain:8800/'
 GEM_OQ_ENGSERV_KEY='oq-platform'
 GEM_OQ_BING_KEY=''
 
@@ -323,15 +322,14 @@ function_exists () {
 #
 locset_create () {
     local oqpdir gem_hostname gem_secr_key gem_db_name gem_db_user gem_db_pass
-    local gem_hazard_calc_addr gem_risk_calc_addr gem_oq_engserv_key gem_oq_bing_key
+    local gem_webuiurl gem_oq_engserv_key gem_oq_bing_key
     oqpdir="$1" ; shift
     gem_hostname="$1" ; shift
     gem_secr_key="$1" ; shift
     gem_db_name="$1" ; shift
     gem_db_user="$1" ; shift
     gem_db_pass="$1" ; shift
-    gem_hazard_calc_addr="$1" ; shift
-    gem_risk_calc_addr="$1" ; shift
+    gem_webuiurl="$1" ; shift
     gem_oq_engserv_key="$1"; shift
     gem_oq_bing_key="$1"
 
@@ -349,8 +347,7 @@ with open('$GEM_LOCAL_SETTINGS', 'w') as fh:
                                    db_pass='${gem_db_pass}',
                                    geonode_port=80,
                                    geoserver_port=8080,
-                                   hazard_calc_addr='${gem_hazard_calc_addr}',
-                                   risk_calc_addr='${gem_risk_calc_addr}',
+                                   webuiurl='${gem_webuiurl}',
                                    oq_engserv_key='${gem_oq_engserv_key}',
                                    oq_bing_key='${gem_oq_bing_key}',
                                    oq_secret_key='${gem_secr_key}',
@@ -478,8 +475,7 @@ oq_platform_install () {
     gem_db_user="${globargs['db_user']:-$GEM_DB_USER}"
     gem_db_pass="${globargs['db_pass']:-$GEM_DB_PASS}"
 
-    gem_hazard_calc_addr="${globargs['hazard_calc_addr']:-$GEM_HAZARD_CALC_ADDR}"
-    gem_risk_calc_addr="${globargs['risk_calc_addr']:-$GEM_RISK_CALC_ADDR}"
+    gem_webuiurl="${globargs['webuiurl']:-$GEM_WEBUIURL}"
     gem_oq_engserv_key="${globargs['oq_engserv_key']:-$GEM_OQ_ENGSERV_KEY}"
     gem_oq_bing_key="${globargs['oq_bing_key']:-$GEM_OQ_BING_KEY}"
 
@@ -577,7 +573,7 @@ oq_platform_install () {
         mv /etc/openquake/platform/local_settings.py /etc/openquake/platform/local_settings.py.orig
     fi
 
-    locset_create "$oqpdir" "$gem_hostname" "$gem_secr_key" "$gem_db_name" "$gem_db_user" "$gem_db_pass" "${gem_hazard_calc_addr}" "${gem_risk_calc_addr}" "${gem_oq_engserv_key}"  "${gem_oq_bing_key}"
+    locset_create "$oqpdir" "$gem_hostname" "$gem_secr_key" "$gem_db_name" "$gem_db_user" "$gem_db_pass" "${gem_webuiurl}" "${gem_oq_engserv_key}"  "${gem_oq_bing_key}"
 
     if [ "$GEM_IS_INSTALL" != "y" ]; then
 	mv /etc/openquake/platform/local_settings.py /etc/openquake/platform/local_settings.py.new
@@ -708,7 +704,7 @@ oq_platform_install () {
 
 usage() {
     local com="$1" ret="$2"
-    echo "${com} <--help|-p> <--hostname|-H> hostname [<--db_name|-d> db_name] [<--db_user|-u> db_user] [<--hazard_calc_addr|-h> <addr>] [<--risk_calc_addr|-r> <addr>] [<--oq_engserv_key|-k> <key>] [<--oq_bing_key|-B> <bing-key>]"
+    echo "${com} <--help|-p> <--hostname|-H> hostname [<--db_name|-d> db_name] [<--db_user|-u> db_user] [<--webuiurl|-w> <addr>] [<--oq_engserv_key|-k> <key>] [<--oq_bing_key|-B> <bing-key>]"
     exit $ret
 }
 
@@ -729,7 +725,7 @@ fi
 wai="$(whoami)"
 
 if [ "$wai" = "root" ]; then
-    parsargs "norm_user|U:,norm_dir|D:,help|p,hostname|H:,db_name|d:,db_user|u:,hazard_calc_addr|h:,risk_calc_addr|r:,oq_engserv_key|k:,oq_bing_key|B:" "$@"
+    parsargs "norm_user|U:,norm_dir|D:,help|p,hostname|H:,db_name|d:,db_user|u:,webuiurl|w:,oq_engserv_key|k:,oq_bing_key|B:" "$@"
     if [ "${globargs['hostname']}" == "" ]; then
         usage "$0" 1
     fi
@@ -737,7 +733,7 @@ if [ "$wai" = "root" ]; then
     oq_platform_install
     exit $?
 else
-    parsargs "help|p,hostname|H:,db_name|d:,db_user|u:,hazard_calc_addr|h:,risk_calc_addr|r:,oq_engserv_key|k:,oq_bing_key|B:" "$@"
+    parsargs "help|p,hostname|H:,db_name|d:,db_user|u:,webuiurl|w:,oq_engserv_key|k:,oq_bing_key|B:" "$@"
 
     if [ "${globargs['hostname']}" == "" -o "${globargs['help']}" ]; then
         usage "$0" 1

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -573,7 +573,7 @@ oq_platform_install () {
         mv /etc/openquake/platform/local_settings.py /etc/openquake/platform/local_settings.py.orig
     fi
 
-    locset_create "$oqpdir" "$gem_hostname" "$gem_secr_key" "$gem_db_name" "$gem_db_user" "$gem_db_pass" "${gem_webuiurl}" "${gem_oq_engserv_key}"  "${gem_oq_bing_key}"
+    locset_create "$oqpdir" "$gem_hostname" "$gem_secr_key" "$gem_db_name" "$gem_db_user" "$gem_db_pass" "${gem_webuiurl}" "${gem_oq_engserv_key}" "${gem_oq_bing_key}"
 
     if [ "$GEM_IS_INSTALL" != "y" ]; then
 	mv /etc/openquake/platform/local_settings.py /etc/openquake/platform/local_settings.py.new

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -525,13 +525,10 @@ oq_platform_install () {
 
     add-apt-repository -y ppa:openquake/ppa
     apt-get update
-    apt-get install -y --force-yes geonode python-geonode-user-accounts
+    apt-get install -y --force-yes geonode python-geonode-user-accounts python-oq-engine
 
-    # add dependencies to use nrml validation as library
-    apt-get install -y --force-yes python-decorator python-h5py python-psutil python-concurrent.futures python-pyshp python-scipy python-numpy python-shapely python-mock python-requests python-docutils
-
-    pip install --no-deps openquake.hazardlib
-    pip install --no-deps openquake.engine
+    # add dependencies to use oq webui as service
+    apt-get install -y --force-yes python-requests
 
     # FIXME this code will be used in the future
     ## check for oq-platform packaged dependencies

--- a/openquakeplatform/bin/deploy.sh
+++ b/openquakeplatform/bin/deploy.sh
@@ -49,7 +49,7 @@ fi
 GEM_DB_NAME='oqplatform'
 GEM_DB_USER='oqplatform'
 GEM_DB_PASS='the-password'
-GEM_WEBUIURL='http://localhost.localdomain:8800/'
+GEM_WEBUIURL='localhost.localdomain:8800'
 GEM_OQ_ENGSERV_KEY='oq-platform'
 GEM_OQ_BING_KEY=''
 

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -49,7 +49,7 @@ GEM_LOCAL_SETTINGS_TMPL = 'openquakeplatform/local_settings.py.template'
 
 def _check_oq_engine_webui():
     try:
-        ret_code = local('python -c "import requests ; x = requests.get(\"http://localhost.localdomain:8800/engine_version\") ; print x.status_code"', capture=True)
+        ret_code = local('python -c "import requests ; x = requests.get(\\"http://localhost.localdomain:8800/engine_version\\") ; print x.status_code"', capture=True)
         if ret_code != "200":
             raise SystemExit
     except SystemExit:

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -302,7 +302,7 @@ def _write_local_settings(hostname, db_name, db_user, db_pass,
                                        mediaroot=mediaroot,
                                        staticroot=staticroot,
                                        is_gem_experimental=True,
-                                       datadir='data/'
+                                       datadir="data/"
                                        ))
 
 

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -49,7 +49,7 @@ GEM_LOCAL_SETTINGS_TMPL = 'openquakeplatform/local_settings.py.template'
 
 def _check_oq_engine_webui():
     try:
-        ret_code = local('python -c "import requests ; x = requests.get(\"http://localhost:8800/engine_version\") ; print x.status_code"', capture=True)
+        ret_code = local('python -c "import requests ; x = requests.get(\"http://localhost.localdomain:8800/engine_version\") ; print x.status_code"', capture=True)
         if ret_code != "200":
             raise SystemExit
     except SystemExit:

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -66,7 +66,7 @@ def bootstrap(db_name=None, db_user=None,
               db_pass=DB_PASSWORD, hostname='oq-platform.localdomain',
               geonode_port=None,
               geoserver_port=None,
-              webuiurl='http://oq-platform.localdomain:8800',
+              webuiurl='localhost.localdomain:8800',
               oq_engserv_key='oq-platform',
               oq_bing_key='',
               mediaroot=None, staticroot='/home'):
@@ -131,7 +131,7 @@ def bootstrap(db_name=None, db_user=None,
 
 def baseenv(hostname, db_name='oqplatform', db_user='oqplatform', db_pass=DB_PASSWORD,
             geonode_port=None, geoserver_port=None,
-            webuiurl='http://oq-platform.localdomain:8800',
+            webuiurl='localhost.localdomain:8800',
             oq_engserv_key='oq-platform',
             oq_secret_key=None, oq_bing_key='',
             mediaroot=None, staticroot='/home'):

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -47,26 +47,19 @@ GEM_DB_USER = os.getenv('GEM_DB_USER', 'oqplatform')
 #: Template for local_settings.py
 GEM_LOCAL_SETTINGS_TMPL = 'openquakeplatform/local_settings.py.template'
 
-def _check_risklib_nrmllib():
+def _check_oq_engine_webui():
     try:
-        local('python -c "from openquake.hazardlib import nrml" >/dev/null 2>&1')
+        ret_code = local('python -c "import requests ; x = requests.get(\"http://localhost:8800/engine_version\") ; print x.status_code"', capture=True)
+        if ret_code != "200":
+            raise SystemExit
     except SystemExit:
         print """
-WARNING: 'openquake.hazardlib.nrml' from 'oq-hazardlib' not found,
-'ipt' application will not work properly; to add it you can choose one
-of these solutions:
-
-- install 'oq-hazardlib' and 'oq-engine' packages with pip directly from git running:
+WARNING: 'webui service is not working on port 8800, please install
+'python-oq-engine' package from openquake repository to enable it:
    sudo apt-get install python-software-properties
    sudo add-apt-repository ppa:openquake/ppa
    sudo apt-get update
-   sudo apt-get install python-decorator python-h5py python-psutil python-concurrent.futures
-   # (into virtualenv)
-   pip install 'http://github.com/gem/oq-hazardlib/tarball/master'
-   pip install 'http://github.com/gem/oq-engine/tarball/master'
-
-- download 'oq-hazardlib' and 'oq-engine' manually from github and make available via PYTHONPATH
-  before run any python applications
+   sudo apt-get install python-oq-engine
 """
 
 def bootstrap(db_name=None, db_user=None,
@@ -135,7 +128,7 @@ def bootstrap(db_name=None, db_user=None,
     # leave the user with superuser privs.
     # if user_created:
     #    _pgquery('ALTER USER %s WITH NOSUPERUSER' % db_user)
-    _check_risklib_nrmllib()
+    _check_oq_engine_webui()
 
 def baseenv(hostname, db_name='oqplatform', db_user='oqplatform', db_pass=DB_PASSWORD,
             geonode_port=None, geoserver_port=None,

--- a/openquakeplatform/fabfile.py
+++ b/openquakeplatform/fabfile.py
@@ -66,8 +66,7 @@ def bootstrap(db_name=None, db_user=None,
               db_pass=DB_PASSWORD, hostname='oq-platform.localdomain',
               geonode_port=None,
               geoserver_port=None,
-              hazard_calc_addr='http://oq-platform.localdomain:8800',
-              risk_calc_addr='http://oq-platform.localdomain:8800',
+              webuiurl='http://oq-platform.localdomain:8800',
               oq_engserv_key='oq-platform',
               oq_bing_key='',
               mediaroot=None, staticroot='/home'):
@@ -107,8 +106,8 @@ def bootstrap(db_name=None, db_user=None,
 
     baseenv(hostname, db_name=db_name, db_user=db_user, db_pass=db_pass,
             geonode_port=geonode_port, geoserver_port=geoserver_port,
-            hazard_calc_addr=hazard_calc_addr,
-            risk_calc_addr=risk_calc_addr, oq_engserv_key=oq_engserv_key,
+            webuiurl=webuiurl,
+            oq_engserv_key=oq_engserv_key,
             oq_secret_key=oq_secret_key, oq_bing_key=oq_bing_key,
             mediaroot=mediaroot, staticroot=staticroot)
 
@@ -132,8 +131,7 @@ def bootstrap(db_name=None, db_user=None,
 
 def baseenv(hostname, db_name='oqplatform', db_user='oqplatform', db_pass=DB_PASSWORD,
             geonode_port=None, geoserver_port=None,
-            hazard_calc_addr='http://oq-platform.localdomain:8800',
-            risk_calc_addr='http://oq-platform.localdomain:8800',
+            webuiurl='http://oq-platform.localdomain:8800',
             oq_engserv_key='oq-platform',
             oq_secret_key=None, oq_bing_key='',
             mediaroot=None, staticroot='/home'):
@@ -147,7 +145,7 @@ def baseenv(hostname, db_name='oqplatform', db_user='oqplatform', db_pass=DB_PAS
     if mediaroot is None:
         mediaroot = os.path.join(os.getcwd(), "uploaded")
 
-    _write_local_settings(hostname, db_name, db_user, db_pass, geonode_port, geoserver_port, hazard_calc_addr, risk_calc_addr, oq_engserv_key, oq_secret_key, oq_bing_key, mediaroot, staticroot)
+    _write_local_settings(hostname, db_name, db_user, db_pass, geonode_port, geoserver_port, webuiurl, oq_engserv_key, oq_secret_key, oq_bing_key, mediaroot, staticroot)
     # Create the user if it doesn't already exist
     # User will have superuser privileges for running
     # syncdb (part of `paver setup` below), etc.
@@ -286,8 +284,7 @@ def test_with_xunit():
 
 def _write_local_settings(hostname, db_name, db_user, db_pass,
                           geonode_port, geoserver_port,
-                          hazard_calc_addr, risk_calc_addr,
-                          oq_engserv_key, oq_secret_key,
+                          webuiurl, oq_engserv_key, oq_secret_key,
                           oq_bing_key, mediaroot, staticroot):
     local_settings = open(GEM_LOCAL_SETTINGS_TMPL, 'r').read()
     with open('openquakeplatform/local_settings.py', 'w') as fh:
@@ -298,8 +295,7 @@ def _write_local_settings(hostname, db_name, db_user, db_pass,
                                        geonode_port=geonode_port,
                                        geoserver_port=geoserver_port,
                                        siteurl="%s:%s" % (hostname, geonode_port),
-                                       hazard_calc_addr=hazard_calc_addr,
-                                       risk_calc_addr=risk_calc_addr,
+                                       webuiurl=webuiurl,
                                        oq_engserv_key=oq_engserv_key,
                                        oq_secret_key=oq_secret_key,
                                        oq_bing_key=oq_bing_key,

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -6,6 +6,7 @@ from geonode.settings import TEMPLATE_CONTEXT_PROCESSORS
 
 SITENAME = 'OpenQuake Platform'
 SITEURL = 'http://%(siteurl)s/'
+WEBUIURL = '%(webuiurl)'
 
 OQPLATFORM_ROOT = os.path.dirname(openquakeplatform.__file__)
 GEONODE_ROOT = os.path.abspath(os.path.dirname(geonode.__file__))

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -6,7 +6,7 @@ from geonode.settings import TEMPLATE_CONTEXT_PROCESSORS
 
 SITENAME = 'OpenQuake Platform'
 SITEURL = 'http://%(siteurl)s/'
-WEBUIURL = '%(webuiurl)'
+WEBUIURL = '%(webuiurl)s'
 
 OQPLATFORM_ROOT = os.path.dirname(openquakeplatform.__file__)
 GEONODE_ROOT = os.path.abspath(os.path.dirname(geonode.__file__))

--- a/openquakeplatform/openquakeplatform/local_settings.py.template
+++ b/openquakeplatform/openquakeplatform/local_settings.py.template
@@ -6,7 +6,7 @@ from geonode.settings import TEMPLATE_CONTEXT_PROCESSORS
 
 SITENAME = 'OpenQuake Platform'
 SITEURL = 'http://%(siteurl)s/'
-WEBUIURL = '%(webuiurl)s'
+WEBUIURL = 'http://%(webuiurl)s/'
 
 OQPLATFORM_ROOT = os.path.dirname(openquakeplatform.__file__)
 GEONODE_ROOT = os.path.abspath(os.path.dirname(geonode.__file__))

--- a/openquakeplatform/openquakeplatform/test/isc_test.py
+++ b/openquakeplatform/openquakeplatform/test/isc_test.py
@@ -3,6 +3,7 @@ import unittest
 
 from openquakeplatform.test import pla
 
+@unittest.skip("temporarily disabled")
 class IscTest(unittest.TestCase):
     def isc_test(self):
         pla.get('/explore')

--- a/openquakeplatform/openquakeplatform/test/isc_test.py
+++ b/openquakeplatform/openquakeplatform/test/isc_test.py
@@ -43,9 +43,10 @@ class IscTest(unittest.TestCase):
             "-10018754.17,0,-5009377.085,5009377.085&WIDTH=256&HEIGHT=256')]",
             50)
 
+        x = tail_ptr['x']
+        y = tail_ptr['y']
+
         pla.add_click_event()
-        pla.click_at(107 + tail_ptr.location['x'],
-                     115 + tail_ptr.location['y'])
-        # raise ValueError
+        pla.click_at(107 + x, 115 + y)
 
         pla.xpath_finduniq("//div[text() = '1951-03-19T04:23:00']", 50)

--- a/openquakeplatform/openquakeplatform/test/isc_test.py
+++ b/openquakeplatform/openquakeplatform/test/isc_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 import unittest
+import time
 
 from openquakeplatform.test import pla
 
-@unittest.skip("temporarily disabled")
+# @unittest.skip("temporarily disabled")
 class IscTest(unittest.TestCase):
     def isc_test(self):
         pla.get('/explore')
@@ -37,6 +38,7 @@ class IscTest(unittest.TestCase):
             "= 'Identify']/../../../../..[contains(concat(' ', @class, ' '),"
             " ' x-btn-pressed ')]", 100)
 
+        time.sleep(3)
         tail_ptr = pla.xpath_finduniq(
             "//img[contains(@src, 'wms?LAYERS=oqplatform%3Aisc_viewer_measure"
             "&FORMAT=image%2Fpng&TRANSPARENT=TRUE&SERVICE=WMS&VERSION=1.1.1"
@@ -44,8 +46,8 @@ class IscTest(unittest.TestCase):
             "-10018754.17,0,-5009377.085,5009377.085&WIDTH=256&HEIGHT=256')]",
             50)
 
-        x = tail_ptr['x']
-        y = tail_ptr['y']
+        x = tail_ptr.location['x']
+        y = tail_ptr.location['y']
 
         pla.add_click_event()
         pla.click_at(107 + x, 115 + y)

--- a/openquakeplatform/openquakeplatform/test/nose_runner.py
+++ b/openquakeplatform/openquakeplatform/test/nose_runner.py
@@ -1,6 +1,0 @@
-import nose
-
-from openquakeplatform.test.failurecatcher import FailureCatcher
-
-if __name__ == '__main__':
-    nose.main(addplugins=[FailureCatcher()])

--- a/verifier.sh
+++ b/verifier.sh
@@ -338,7 +338,7 @@ _devtest_innervm_run () {
     ssh -t  $lxc_ip "sudo apt-get install -y --force-yes build-essential python-dev python-imaging python-virtualenv git postgresql-9.1 postgresql-server-dev-9.1 postgresql-contrib-9.1 postgresql-9.1-postgis openjdk-6-jre libxml2 libxml2-dev libxslt1-dev libxslt1.1 libblas-dev liblapack-dev curl wget xmlstarlet imagemagick gfortran python-nose libgeos-dev python-software-properties"
     ssh -t  $lxc_ip "sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master"
     ssh -t  $lxc_ip "sudo apt-get update"
-    ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-decorator python-h5py python-psutil python-concurrent.futures python-pyshp python-scipy python-numpy python-shapely python-mock python-requests python-docutils python-oq-engine"
+    ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-oq-engine"
 
     # to allow mixed openquake packages installation (from packages and from sources) an 'ad hoc' __init__.py injection.
     ssh -t  $lxc_ip "sudo echo \"try:
@@ -579,7 +579,7 @@ _prodtest_innervm_run () {
     ssh -t  $lxc_ip "sudo apt-get install -y --force-yes build-essential python-dev python-imaging python-virtualenv git postgresql-9.1 postgresql-server-dev-9.1 postgresql-9.1-postgis openjdk-6-jre libxml2 libxml2-dev libxslt1-dev libxslt1.1 libblas-dev liblapack-dev curl wget xmlstarlet imagemagick gfortran python-nose libgeos-dev python-software-properties"
     ssh -t  $lxc_ip "sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master"
     ssh -t  $lxc_ip "sudo apt-get update"
-    ssh -t  $lxc_ip "sudo apt-get install python-oq-engine"
+    ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-oq-engine"
 
     ssh -t  $lxc_ip "sudo sed -i '1 s@^@local   all             all                                     trust\nhost    all             all             $lxc_ip/32          md5\n@g' /etc/postgresql/9.1/main/pg_hba.conf"
 

--- a/verifier.sh
+++ b/verifier.sh
@@ -440,7 +440,7 @@ python ./manage.py loaddata dev-data.json.bz2
 export PYTHONPATH=\$(pwd):\$(pwd)/openquakeplatform/test/config
 cp openquakeplatform/test/config/moon_config.py.tmpl openquakeplatform/test/config/moon_config.py
 export DISPLAY=:1
-python -m openquake.moon.nose_runner --failurecatcher dev -v --with-xunit --xunit-file=xunit-platform-dev.xml openquakeplatform/test #  || true
+python -m openquake.moon.nose_runner --failurecatcher dev -v --with-xunit --xunit-file=xunit-platform-dev.xml openquakeplatform/test # || true
 # sleep 20000 || true
 # sleep 3
 fab stop

--- a/verifier.sh
+++ b/verifier.sh
@@ -55,7 +55,7 @@
 # sed -i 's/127.0.1.1   \+\([^ ]\+\)/127.0.1.1   \1 \1.gem.lan/g'  /etc/hosts
 # echo -e "y\ny\ny\n" | ./oq-platform/openquakeplatform/bin/deploy.sh -H $hname
 
-# export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
+export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
 if [ $GEM_SET_DEBUG ]; then
     set -x
 fi

--- a/verifier.sh
+++ b/verifier.sh
@@ -338,7 +338,7 @@ _devtest_innervm_run () {
     ssh -t  $lxc_ip "sudo apt-get install -y --force-yes build-essential python-dev python-imaging python-virtualenv git postgresql-9.1 postgresql-server-dev-9.1 postgresql-contrib-9.1 postgresql-9.1-postgis openjdk-6-jre libxml2 libxml2-dev libxslt1-dev libxslt1.1 libblas-dev liblapack-dev curl wget xmlstarlet imagemagick gfortran python-nose libgeos-dev python-software-properties"
     ssh -t  $lxc_ip "sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master"
     ssh -t  $lxc_ip "sudo apt-get update"
-    ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-oq-engine"
+    ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-requests python-oq-engine"
 
     # to allow mixed openquake packages installation (from packages and from sources) an 'ad hoc' __init__.py injection.
     ssh -t  $lxc_ip "sudo echo \"try:
@@ -646,7 +646,7 @@ sudo python -m py_compile \"\${init_file}\"
 export PYTHONPATH=\$(pwd):\$(pwd)/openquakeplatform/test/config
 sed 's@^pla_basepath *= *\"http://localhost:8000\"@pla_basepath = \"http://oq-platform.localdomain\"@g' openquakeplatform/test/config/moon_config.py.tmpl > openquakeplatform/test/config/moon_config.py
 export DISPLAY=:1
-python -m openquake.moon.nose_runner --failurecatcher prod -v --with-xunit --xunit-file=xunit-platform-prod.xml openquakeplatform/test # || true
+python -m openquake.moon.nose_runner --failurecatcher prod -v --with-xunit --xunit-file=xunit-platform-prod.xml openquakeplatform/test || true
 sleep 40000 || true
 sleep 3
 cd -

--- a/verifier.sh
+++ b/verifier.sh
@@ -55,9 +55,9 @@
 # sed -i 's/127.0.1.1   \+\([^ ]\+\)/127.0.1.1   \1 \1.gem.lan/g'  /etc/hosts
 # echo -e "y\ny\ny\n" | ./oq-platform/openquakeplatform/bin/deploy.sh -H $hname
 
-export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
 if [ $GEM_SET_DEBUG ]; then
     set -x
+    export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
 fi
 set -e
 GEM_GIT_REPO="git://github.com/gem"
@@ -375,6 +375,7 @@ rem_sig_hand() {
 trap rem_sig_hand ERR
 set -e
 if [ \$GEM_SET_DEBUG ]; then
+    export PS4='+\${BASH_SOURCE}:\${LINENO}:\${FUNCNAME[0]}: '
     set -x
 fi
 cd ~/$GEM_GIT_PACKAGE
@@ -402,6 +403,7 @@ cd openquakeplatform
 if [ 1 -eq 1 ]; then
     # NEW METHOD: more simple to prevent hang
     fab --show=everything bootstrap
+    sleep 40000 | true
 else
     # OLD METHOD
     nohup fab --show=everything bootstrap &
@@ -601,6 +603,7 @@ rem_sig_hand() {
 trap rem_sig_hand ERR
 set -e
 if [ \$GEM_SET_DEBUG ]; then
+    export PS4='+\${BASH_SOURCE}:\${LINENO}:\${FUNCNAME[0]}: '
     set -x
 fi
 
@@ -644,7 +647,7 @@ export PYTHONPATH=\$(pwd):\$(pwd)/openquakeplatform/test/config
 sed 's@^pla_basepath *= *\"http://localhost:8000\"@pla_basepath = \"http://oq-platform.localdomain\"@g' openquakeplatform/test/config/moon_config.py.tmpl > openquakeplatform/test/config/moon_config.py
 export DISPLAY=:1
 python -m openquake.moon.nose_runner --failurecatcher prod -v --with-xunit --xunit-file=xunit-platform-prod.xml openquakeplatform/test # || true
-# sleep 40000 || true
+sleep 40000 || true
 sleep 3
 cd -
 "

--- a/verifier.sh
+++ b/verifier.sh
@@ -403,7 +403,7 @@ cd openquakeplatform
 if [ 1 -eq 1 ]; then
     # NEW METHOD: more simple to prevent hang
     fab --show=everything bootstrap
-    sleep 40000 | true
+    # sleep 40000 | true
 else
     # OLD METHOD
     nohup fab --show=everything bootstrap &
@@ -646,8 +646,8 @@ sudo python -m py_compile \"\${init_file}\"
 export PYTHONPATH=\$(pwd):\$(pwd)/openquakeplatform/test/config
 sed 's@^pla_basepath *= *\"http://localhost:8000\"@pla_basepath = \"http://oq-platform.localdomain\"@g' openquakeplatform/test/config/moon_config.py.tmpl > openquakeplatform/test/config/moon_config.py
 export DISPLAY=:1
-python -m openquake.moon.nose_runner --failurecatcher prod -v --with-xunit --xunit-file=xunit-platform-prod.xml openquakeplatform/test || true
-sleep 40000 || true
+python -m openquake.moon.nose_runner --failurecatcher prod -v --with-xunit --xunit-file=xunit-platform-prod.xml openquakeplatform/test # || true
+# sleep 40000 || true
 sleep 3
 cd -
 "

--- a/verifier.sh
+++ b/verifier.sh
@@ -338,8 +338,7 @@ _devtest_innervm_run () {
     ssh -t  $lxc_ip "sudo apt-get install -y --force-yes build-essential python-dev python-imaging python-virtualenv git postgresql-9.1 postgresql-server-dev-9.1 postgresql-contrib-9.1 postgresql-9.1-postgis openjdk-6-jre libxml2 libxml2-dev libxslt1-dev libxslt1.1 libblas-dev liblapack-dev curl wget xmlstarlet imagemagick gfortran python-nose libgeos-dev python-software-properties"
     ssh -t  $lxc_ip "sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master"
     ssh -t  $lxc_ip "sudo apt-get update"
-    ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-decorator python-h5py python-psutil python-concurrent.futures python-pyshp python-scipy python-numpy python-shapely python-mock python-requests python-docutils"
-
+    ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-decorator python-h5py python-psutil python-concurrent.futures python-pyshp python-scipy python-numpy python-shapely python-mock python-requests python-docutils python-oq-engine"
 
     # to allow mixed openquake packages installation (from packages and from sources) an 'ad hoc' __init__.py injection.
     ssh -t  $lxc_ip "sudo echo \"try:
@@ -387,8 +386,6 @@ source platform-env/bin/activate
 # aren't tested anymore with Precise's stack, so --no-deps is
 # used. We need it for oq-platform-* too because pip tries to
 # resolve dependencies of dependencies too.
-pip install --no-deps openquake.hazardlib
-pip install --no-deps openquake.engine
 pip install --no-deps \$HOME/oq-moon
 pip install --no-deps -e \$HOME/oq-platform-ipt
 pip install --no-deps -e \$HOME/oq-platform-taxtweb
@@ -582,6 +579,7 @@ _prodtest_innervm_run () {
     ssh -t  $lxc_ip "sudo apt-get install -y --force-yes build-essential python-dev python-imaging python-virtualenv git postgresql-9.1 postgresql-server-dev-9.1 postgresql-9.1-postgis openjdk-6-jre libxml2 libxml2-dev libxslt1-dev libxslt1.1 libblas-dev liblapack-dev curl wget xmlstarlet imagemagick gfortran python-nose libgeos-dev python-software-properties"
     ssh -t  $lxc_ip "sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master"
     ssh -t  $lxc_ip "sudo apt-get update"
+    ssh -t  $lxc_ip "sudo apt-get install python-oq-engine"
 
     ssh -t  $lxc_ip "sudo sed -i '1 s@^@local   all             all                                     trust\nhost    all             all             $lxc_ip/32          md5\n@g' /etc/postgresql/9.1/main/pg_hba.conf"
 


### PR DESCRIPTION
With this PR oq-platform is decoupled from the oq-engine code-base just interacting via http requests.
It is companion of oq-platform-ipt PR https://github.com/gem/oq-platform-ipt/pull/29.
Tests are green here: https://ci.openquake.org/job/zdevel_oq-platform/410/