### PR TITLE
We do not provide nightly packages for precise anymore

### DIFF
--- a/verifier.sh
+++ b/verifier.sh
@@ -342,7 +342,7 @@ _devtest_innervm_run () {
     ssh -t  $lxc_ip "sudo apt-get -y upgrade"
 
     ssh -t  $lxc_ip "sudo apt-get install -y --force-yes build-essential python-dev python-imaging python-virtualenv git postgresql-9.1 postgresql-server-dev-9.1 postgresql-contrib-9.1 postgresql-9.1-postgis openjdk-6-jre libxml2 libxml2-dev libxslt1-dev libxslt1.1 libblas-dev liblapack-dev curl wget xmlstarlet imagemagick gfortran python-nose libgeos-dev python-software-properties"
-    ssh -t  $lxc_ip "sudo add-apt-repository -y ppa:openquake-automatic-team/latest-master"
+    ssh -t  $lxc_ip "sudo add-apt-repository -y ppa:openquake/release-2.4"
     ssh -t  $lxc_ip "sudo apt-get update"
     ssh -t  $lxc_ip "sudo apt-get install -y --force-yes python-requests python-oq-engine"
 


### PR DESCRIPTION
So we should use the latest stable package available for now (engine 2.4)

https://ci.openquake.org/job/zdevel_oq-platform/435