### PR TITLE
Vuln name less constr

### DIFF
--- a/openquakeplatform/openquakeplatform/__init__.py
+++ b/openquakeplatform/openquakeplatform/__init__.py
@@ -15,5 +15,5 @@
 
 import version
 
-__version__ = '1.10.0'
+__version__ = '1.10.1'
 __version__ += version.git_suffix(__file__)

--- a/openquakeplatform/openquakeplatform/vulnerability/models.py
+++ b/openquakeplatform/openquakeplatform/vulnerability/models.py
@@ -666,6 +666,8 @@ TYPES_OF_ASSESSMENT = (
     (TA.CAPACITY_CURVE, 'Capacity curve'),
 )
 
+TYPES_OF_ASSESSMENT_REV = tuple((x[1], x[0]) for x in TYPES_OF_ASSESSMENT)
+
 
 class IMT(object):
     PGA = 1
@@ -1389,8 +1391,10 @@ STRUCTURE_TYPES = (
 
 
 class GeneralInformationManager(models.Manager):
-    def get_by_natural_key(self, name):
-        return self.get(name=name)
+    def get_by_natural_key(self, name, type_of_assessment):
+        return self.get(name=name,
+            type_of_assessment=dict(
+                TYPES_OF_ASSESSMENT_REV)[type_of_assessment])
 
 
 # A
@@ -1403,10 +1407,11 @@ class GeneralInformation(SingleOwnerMixin, models.Model):
 
     class Meta:
         verbose_name = "function"
-        ordering = ['name']
+        ordering = ['name', 'type_of_assessment']
+        unique_together = ('name', 'type_of_assessment')
 
     # A.1 Reference ID code/name: choose integer(code)/string(name)
-    name = models.CharField(max_length=CHMAX, unique=True)
+    name = models.CharField(max_length=CHMAX)
     category = models.IntegerField(choices=CATEGORIES)
     # For category in (Structure specific, Structure class)
     # it's possible to select among
@@ -1456,7 +1461,7 @@ class GeneralInformation(SingleOwnerMixin, models.Model):
     objects = GeneralInformationManager()
 
     def natural_key(self):
-        return (self.name,)
+        return (self.name, dict(TYPES_OF_ASSESSMENT)[self.type_of_assessment])
 
     def clean(self):
         if int(self.category) not in (CAT.STR_SPEC, CAT.STR_CLASS):


### PR DESCRIPTION
Change constraint on curve name from 'unique' to 'unique with type_of_assessment'.
Migration between old and new version must be performed with:
```
  postgres@machine:~$ pg_dump -a --inserts -t 'vulnerability_*' oqplatform > vulnerability.sql
  user@machine: ~$ sudo openquakeplatform sqlclear vulnerability | sudo openquakeplatform dbshell
  user@machine: ~$ sudo pip install -U --no-deps oq-platform/openquakeplatform/
  user@machine: ~$ sudo openquakeplatform syncdb
  postgres@machine:~$ psql oqplatform vulnerability.sql
```
tests are running here: https://ci.openquake.org/job/zdevel_oq-platform/436/